### PR TITLE
fix(ssh): validate access tokens in keyboard-interactive auth

### DIFF
--- a/pkg/backend/user.go
+++ b/pkg/backend/user.go
@@ -27,15 +27,22 @@ func (d *Backend) AccessLevel(ctx context.Context, repo string, username string)
 //
 // It implements backend.Backend.
 func (d *Backend) AccessLevelByPublicKey(ctx context.Context, repo string, pk ssh.PublicKey) access.AccessLevel {
-	for _, k := range d.cfg.AdminKeys() {
-		if sshutils.KeysEqual(pk, k) {
-			return access.AdminAccess
+	if pk != nil {
+		for _, k := range d.cfg.AdminKeys() {
+			if sshutils.KeysEqual(pk, k) {
+				return access.AdminAccess
+			}
+		}
+
+		user, _ := d.UserByPublicKey(ctx, pk)
+		if user != nil {
+			return d.AccessLevel(ctx, repo, user.Username())
 		}
 	}
 
-	user, _ := d.UserByPublicKey(ctx, pk)
-	if user != nil {
-		return d.AccessLevel(ctx, repo, user.Username())
+	// Fall back to the context user (e.g., authenticated via access token).
+	if ctxUser := proto.UserFromContext(ctx); ctxUser != nil {
+		return d.AccessLevel(ctx, repo, ctxUser.Username())
 	}
 
 	return d.AccessLevel(ctx, repo, "")

--- a/pkg/ssh/cmd/cmd.go
+++ b/pkg/ssh/cmd/cmd.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -107,6 +108,21 @@ func CommandName(args []string) string {
 		return ""
 	}
 	return args[0]
+}
+
+// currentUser resolves the authenticated user from the session context.
+// It first tries public key auth, then falls back to the context user
+// (e.g., set by access token authentication).
+func currentUser(ctx context.Context, be *backend.Backend) (proto.User, error) {
+	pk := sshutils.PublicKeyFromContext(ctx)
+	if pk != nil {
+		return be.UserByPublicKey(ctx, pk)
+	}
+	user := proto.UserFromContext(ctx)
+	if user != nil {
+		return user, nil
+	}
+	return nil, proto.ErrUserNotFound
 }
 
 func checkIfReadable(cmd *cobra.Command, args []string) error {

--- a/pkg/ssh/cmd/info.go
+++ b/pkg/ssh/cmd/info.go
@@ -15,8 +15,7 @@ func InfoCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			be := backend.FromContext(ctx)
-			pk := sshutils.PublicKeyFromContext(ctx)
-			user, err := be.UserByPublicKey(ctx, pk)
+			user, err := currentUser(ctx, be)
 			if err != nil {
 				return err
 			}

--- a/pkg/ssh/cmd/list.go
+++ b/pkg/ssh/cmd/list.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/charmbracelet/soft-serve/pkg/access"
 	"github.com/charmbracelet/soft-serve/pkg/backend"
-	"github.com/charmbracelet/soft-serve/pkg/sshutils"
+	"github.com/charmbracelet/soft-serve/pkg/proto"
 	"github.com/spf13/cobra"
 )
 
@@ -19,13 +19,13 @@ func listCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			be := backend.FromContext(ctx)
-			pk := sshutils.PublicKeyFromContext(ctx)
+			user := proto.UserFromContext(ctx)
 			repos, err := be.Repositories(ctx)
 			if err != nil {
 				return err
 			}
 			for _, r := range repos {
-				if be.AccessLevelByPublicKey(ctx, r.Name(), pk) >= access.ReadOnlyAccess {
+				if be.AccessLevelForUser(ctx, r.Name(), user) >= access.ReadOnlyAccess {
 					if !r.IsHidden() || all {
 						cmd.Println(r.Name())
 					}

--- a/pkg/ssh/cmd/pubkey.go
+++ b/pkg/ssh/cmd/pubkey.go
@@ -23,8 +23,7 @@ func PubkeyCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			be := backend.FromContext(ctx)
-			pk := sshutils.PublicKeyFromContext(ctx)
-			user, err := be.UserByPublicKey(ctx, pk)
+			user, err := currentUser(ctx, be)
 			if err != nil {
 				return err
 			}
@@ -45,8 +44,7 @@ func PubkeyCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			be := backend.FromContext(ctx)
-			pk := sshutils.PublicKeyFromContext(ctx)
-			user, err := be.UserByPublicKey(ctx, pk)
+			user, err := currentUser(ctx, be)
 			if err != nil {
 				return err
 			}
@@ -68,8 +66,7 @@ func PubkeyCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			be := backend.FromContext(ctx)
-			pk := sshutils.PublicKeyFromContext(ctx)
-			user, err := be.UserByPublicKey(ctx, pk)
+			user, err := currentUser(ctx, be)
 			if err != nil {
 				return err
 			}

--- a/pkg/ssh/cmd/set_username.go
+++ b/pkg/ssh/cmd/set_username.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/charmbracelet/soft-serve/pkg/backend"
-	"github.com/charmbracelet/soft-serve/pkg/sshutils"
 	"github.com/spf13/cobra"
 )
 
@@ -15,8 +14,7 @@ func SetUsernameCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			be := backend.FromContext(ctx)
-			pk := sshutils.PublicKeyFromContext(ctx)
-			user, err := be.UserByPublicKey(ctx, pk)
+			user, err := currentUser(ctx, be)
 			if err != nil {
 				return err
 			}

--- a/pkg/ssh/middleware.go
+++ b/pkg/ssh/middleware.go
@@ -55,17 +55,28 @@ func AuthenticationMiddleware(sh ssh.Handler) ssh.Handler {
 			return
 		}
 
+		// Check if this session was authenticated via access token.
+		tokenUser := perms.Extensions[tokenUserExtKey]
+
 		ac := be.AllowKeyless(ctx)
-		publicKeyCounter.WithLabelValues(strconv.FormatBool(ac || pk != nil)).Inc()
-		if !ac && pk == nil {
+		publicKeyCounter.WithLabelValues(strconv.FormatBool(ac || pk != nil || tokenUser != "")).Inc()
+		if !ac && pk == nil && tokenUser == "" {
 			wish.Fatalln(s, ErrPermissionDenied)
 			return
 		}
 
-		// Set the auth'd user, or anon, in the context
+		// Resolve the authenticated user identity.
 		var user proto.User
 		if pk != nil {
 			user, _ = be.UserByPublicKey(ctx, pk)
+		} else if tokenUser != "" {
+			var err error
+			user, err = be.User(ctx, tokenUser)
+			if err != nil {
+				log.FromContext(ctx).Warn("token-authenticated user not found", "username", tokenUser, "err", err)
+				wish.Fatalln(s, ErrPermissionDenied)
+				return
+			}
 		}
 		ctx.SetValue(proto.ContextKeyUser, user)
 

--- a/pkg/ssh/session.go
+++ b/pkg/ssh/session.go
@@ -47,7 +47,7 @@ func SessionHandler(s ssh.Session) *tea.Program {
 		initialRepo = cmd[0]
 	}
 
-	auth := be.AccessLevelByPublicKey(ctx, initialRepo, s.PublicKey())
+	auth := be.AccessLevelForUser(ctx, initialRepo, proto.UserFromContext(ctx))
 	if auth < access.ReadOnlyAccess {
 		wish.Fatalln(s, proto.ErrUnauthorized)
 		return nil

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -23,6 +23,10 @@ import (
 	gossh "golang.org/x/crypto/ssh"
 )
 
+// tokenUserExtKey is the permissions extension key used to pass the
+// authenticated username from KeyboardInteractiveHandler to AuthenticationMiddleware.
+const tokenUserExtKey = "token-user"
+
 var (
 	publicKeyCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "soft_serve",
@@ -180,18 +184,34 @@ func (s *SSHServer) PublicKeyHandler(ctx ssh.Context, pk ssh.PublicKey) (allowed
 }
 
 // KeyboardInteractiveHandler handles keyboard interactive authentication.
-// This is used after all public key authentication has failed.
-func (s *SSHServer) KeyboardInteractiveHandler(ctx ssh.Context, _ gossh.KeyboardInteractiveChallenge) bool {
-	ac := s.be.AllowKeyless(ctx)
-	keyboardInteractiveCounter.WithLabelValues(strconv.FormatBool(ac)).Inc()
-
-	// If we're allowing keyless access, reset the public key fingerprint
+// It prompts for an access token and validates it. If no valid token is
+// provided, it falls back to AllowKeyless behavior.
+func (s *SSHServer) KeyboardInteractiveHandler(ctx ssh.Context, challenge gossh.KeyboardInteractiveChallenge) bool {
 	initializePermissions(ctx)
 	perms := ctx.Permissions()
 
+	// Prompt the user for an access token.
+	answers, err := challenge("", "", []string{"Access Token: "}, []bool{false})
+	if err == nil && len(answers) > 0 && answers[0] != "" {
+		token := answers[0]
+		user, tokenErr := s.be.UserByAccessToken(ctx, token)
+		if tokenErr == nil && user != nil {
+			// Valid token: store user identity and allow access.
+			perms.Extensions["pubkey-fp"] = ""
+			perms.Extensions[tokenUserExtKey] = user.Username()
+			ctx.SetValue(ssh.ContextKeyPermissions, perms)
+			keyboardInteractiveCounter.WithLabelValues("true").Inc()
+			s.logger.Info("keyboard-interactive token auth succeeded", "username", user.Username())
+			return true
+		}
+		s.logger.Warn("keyboard-interactive token auth failed", "err", tokenErr)
+	}
+
+	// No valid token: fall back to AllowKeyless behavior.
+	ac := s.be.AllowKeyless(ctx)
+	keyboardInteractiveCounter.WithLabelValues(strconv.FormatBool(ac)).Inc()
+
 	if ac {
-		// XXX: reset the public-key fingerprint. This is used to validate the
-		// public key being used to authenticate.
 		perms.Extensions["pubkey-fp"] = ""
 		ctx.SetValue(ssh.ContextKeyPermissions, perms)
 	}

--- a/pkg/ui/pages/selection/selection.go
+++ b/pkg/ui/pages/selection/selection.go
@@ -10,6 +10,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/soft-serve/pkg/access"
 	"github.com/charmbracelet/soft-serve/pkg/backend"
+	"github.com/charmbracelet/soft-serve/pkg/proto"
 	"github.com/charmbracelet/soft-serve/pkg/ui/common"
 	"github.com/charmbracelet/soft-serve/pkg/ui/components/code"
 	"github.com/charmbracelet/soft-serve/pkg/ui/components/selector"
@@ -213,7 +214,7 @@ func (s *Selection) Init() tea.Cmd {
 		if r.IsHidden() {
 			continue
 		}
-		al := be.AccessLevelByPublicKey(ctx, r.Name(), pk)
+		al := be.AccessLevelForUser(ctx, r.Name(), proto.UserFromContext(ctx))
 		if al >= access.ReadOnlyAccess {
 			item, err := NewItem(s.common, r)
 			if err != nil {

--- a/testscript/script_test.go
+++ b/testscript/script_test.go
@@ -95,6 +95,7 @@ func TestScript(t *testing.T) {
 			"soft":                   cmdSoft("admin", admin1.Signer()),
 			"usoft":                  cmdSoft("user1", user1.Signer()),
 			"attacksoft":             cmdSoft("attacker", attackerSigner, attacker.Signer()),
+			"tokensoft":              cmdTokenSoft,
 			"git":                    cmdGit(admin1Key),
 			"ugit":                   cmdGit(user1Key),
 			"agit":                   cmdGit(attackerKey),
@@ -219,6 +220,48 @@ func cmdSoft(user string, keys ...ssh.Signer) func(ts *testscript.TestScript, ne
 
 		check(ts, sess.Run(strings.Join(args, " ")), neg)
 	}
+}
+
+// cmdTokenSoft connects via keyboard-interactive auth using an access token.
+// Usage: tokensoft <token> <command args...>
+func cmdTokenSoft(ts *testscript.TestScript, neg bool, args []string) {
+	if len(args) < 2 {
+		ts.Fatalf("usage: tokensoft <token> <command args...>")
+	}
+	token := args[0]
+	cmdArgs := args[1:]
+
+	cli, err := ssh.Dial(
+		"tcp",
+		net.JoinHostPort("localhost", ts.Getenv("SSH_PORT")),
+		&ssh.ClientConfig{
+			User: "git",
+			Auth: []ssh.AuthMethod{
+				ssh.KeyboardInteractive(func(name, instruction string, questions []string, echos []bool) ([]string, error) {
+					answers := make([]string, len(questions))
+					for i := range questions {
+						answers[i] = token
+					}
+					return answers, nil
+				}),
+			},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		},
+	)
+	if neg && err != nil {
+		return
+	}
+	ts.Check(err)
+	defer cli.Close()
+
+	sess, err := cli.NewSession()
+	ts.Check(err)
+	defer sess.Close()
+
+	sess.Stdout = ts.Stdout()
+	sess.Stderr = ts.Stderr()
+
+	check(ts, sess.Run(strings.Join(cmdArgs, " ")), neg)
 }
 
 func cmdUI(key ssh.Signer) func(ts *testscript.TestScript, neg bool, args []string) {

--- a/testscript/testdata/token-ssh-auth.txtar
+++ b/testscript/testdata/token-ssh-auth.txtar
@@ -1,0 +1,61 @@
+# vi: set ft=conf
+# Test that SSH keyboard-interactive auth validates access tokens
+# and resolves user identity for collaborator-based access control.
+#
+# Regression test for: https://github.com/charmbracelet/soft-serve/issues/800
+
+# start soft serve
+exec soft serve &
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
+
+# create a user with a public key
+soft user create user1 --key "$USER1_AUTHORIZED_KEY"
+
+# create an access token for user1
+usoft token create 'testtoken'
+stdout 'ss_.*'
+cp stdout token.txt
+envfile TOKEN=token.txt
+
+# TEST 1: Valid token authenticates successfully with AllowKeyless=false
+soft settings allow-keyless false
+tokensoft $TOKEN repo list
+
+# TEST 2: Invalid token is rejected with AllowKeyless=false
+! tokensoft invalid-token-value repo list
+
+# TEST 3: Valid token works with AllowKeyless=true
+soft settings allow-keyless true
+tokensoft $TOKEN repo list
+
+# TEST 4: Token-authenticated session has user identity (collaborator access)
+# Create a private repo only accessible to collaborators
+soft repo create private-repo -p
+soft repo collab add private-repo user1
+
+# Connect with valid token — user1 should see the private repo
+soft settings allow-keyless false
+tokensoft $TOKEN repo list
+stdout 'private-repo'
+
+# TEST 5: Invalid token with AllowKeyless=true gets anonymous access (no private repo)
+soft settings allow-keyless true
+tokensoft invalid-token-value repo list
+! stdout 'private-repo'
+
+# TEST 6: info command works with token auth
+soft settings allow-keyless false
+tokensoft $TOKEN info
+stdout 'Username: user1'
+
+# TEST 7: pubkey list works with token auth
+tokensoft $TOKEN pubkey list
+stdout 'ssh-'
+
+# TEST 8: token list works with token auth (uses UserFromContext, already correct)
+tokensoft $TOKEN token list
+stdout 'testtoken'
+
+# stop the server
+[windows] stopserver


### PR DESCRIPTION
## Summary

- **KeyboardInteractiveHandler** now prompts for and validates access tokens via `UserByAccessToken` instead of ignoring the challenge callback
- **AuthenticationMiddleware** resolves user identity for token-authenticated sessions, enabling collaborator-based access control
- Valid tokens are accepted regardless of `AllowKeyless` setting

## Problem

Upstream issue: charmbracelet/soft-serve#800

1. `KeyboardInteractiveHandler` ignored the challenge callback — tokens were never validated. With `AllowKeyless=true` any string was accepted; with `AllowKeyless=false` valid tokens were rejected.
2. Token-authenticated sessions had no user identity in context, so collaborator-based repo filtering was bypassed.

## Changes

- `pkg/ssh/ssh.go` — Use challenge callback to prompt for token, validate via `be.UserByAccessToken()`, store username in `perms.Extensions["token-user"]`
- `pkg/ssh/middleware.go` — Check `token-user` extension, resolve user via `be.User()`, set in context

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/...` passes
- [x] Manual: create user + token, connect with `ssh -o PreferredAuthentications=keyboard-interactive`, verify token is prompted and validated
- [x] Manual: verify collaborator-based repo access works for token-authenticated sessions
- [x] Manual: verify `AllowKeyless=false` rejects empty/invalid tokens but accepts valid ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)