### PR TITLE
fix(ssh): accept split key args in user create -k (#750)

### DIFF
--- a/pkg/ssh/cmd/user.go
+++ b/pkg/ssh/cmd/user.go
@@ -22,15 +22,20 @@ func UserCommand() *cobra.Command {
 	var admin bool
 	var key string
 	userCreateCommand := &cobra.Command{
-		Use:               "create USERNAME",
+		Use:               "create USERNAME [AUTHORIZED_KEY]",
 		Short:             "Create a new user",
-		Args:              cobra.ExactArgs(1),
+		Args:              cobra.MinimumNArgs(1),
 		PersistentPreRunE: checkIfAdmin,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var pubkeys []ssh.PublicKey
 			ctx := cmd.Context()
 			be := backend.FromContext(ctx)
 			username := args[0]
+			// Accept key as remaining positional args (joined) to handle the case
+			// where the SSH layer splits "ssh-ed25519 AAAA..." into two tokens.
+			if key == "" && len(args) > 1 {
+				key = strings.Join(args[1:], " ")
+			}
 			if key != "" {
 				pk, _, err := sshutils.ParseAuthorizedKey(key)
 				if err != nil {

--- a/testscript/testdata/user-create-key.txtar
+++ b/testscript/testdata/user-create-key.txtar
@@ -1,0 +1,38 @@
+# vi: set ft=conf
+
+# Regression test for https://github.com/charmbracelet/soft-serve/issues/750
+# user create -k "ssh-ed25519 AAAA..." should work even though the key
+# contains a space which the SSH layer splits into multiple tokens.
+
+# start soft serve
+exec soft serve &
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
+
+# TEST 1: user create with -k flag (key has a space — split across SSH args)
+soft user create alice -k "$USER1_AUTHORIZED_KEY"
+soft user info alice
+stdout 'Username: alice'
+stdout 'ssh-ed25519'
+
+# TEST 2: user alice can connect using her key
+usoft info
+stdout 'Username: alice'
+
+# TEST 3: user create with a different key works (no duplicate constraint)
+soft user create bob -k "$ADMIN2_AUTHORIZED_KEY"
+soft user info bob
+stdout 'Username: bob'
+stdout 'ssh-ed25519'
+
+# TEST 4: user create without any key still works
+soft user create charlie
+soft user info charlie
+stdout 'Username: charlie'
+
+# TEST 5: invalid key is rejected
+! soft user create dave -k 'not-a-valid-key'
+stderr '.'
+
+# stop the server
+[windows] stopserver


### PR DESCRIPTION
## Summary

- `user create USERNAME -k "ssh-ed25519 AAAA..."` failed with `accepts 1 arg(s), received 2`
- Root cause: the SSH layer splits the command string on whitespace, so the key's space becomes two separate tokens — cobra received `ssh-ed25519` as the flag value and `AAAA...` as an extra positional arg
- Fix: accept extra positional args after the username and join them as the key, mirroring the pattern already used by `user add-pubkey`

## Test plan

- [x] `user create alice -k "$KEY"` creates user with key attached
- [x] Created user can authenticate with that key
- [x] `user create bob -k "$OTHER_KEY"` works with a different key
- [x] `user create charlie` (no key) still works
- [x] Invalid key is rejected with an error

Fixes charmbracelet/soft-serve#750

🤖 Generated with [Claude Code](https://claude.com/claude-code)