### PR TITLE
feat(ui): add 'c' shortcut to copy clone cmd in repo view (#769)

### DIFF
--- a/pkg/ui/pages/repo/repo.go
+++ b/pkg/ui/pages/repo/repo.go
@@ -115,8 +115,11 @@ func (r *Repo) commonHelp() []key.Binding {
 	back.SetHelp("esc", "back to menu")
 	tab := r.common.KeyMap.Section
 	tab.SetHelp("tab", "switch tab")
+	copy := r.common.KeyMap.Copy
+	copy.SetHelp("c", "copy clone cmd")
 	b = append(b, back)
 	b = append(b, tab)
+	b = append(b, copy)
 	return b
 }
 
@@ -204,6 +207,11 @@ func (r *Repo) Update(msg tea.Msg) (common.Model, tea.Cmd) {
 			switch {
 			case key.Matches(msg, r.common.KeyMap.Back):
 				cmds = append(cmds, goBackCmd)
+			case key.Matches(msg, r.common.KeyMap.Copy):
+				if r.selectedRepo != nil {
+					cmd := r.common.CloneCmd(r.common.Config().SSH.PublicURL, r.selectedRepo.Name())
+					cmds = append(cmds, copyCmd(cmd, "Command copied to clipboard"))
+				}
 			}
 		}
 	case CopyMsg:

--- a/testscript/testdata/ui-repo-copy.txtar
+++ b/testscript/testdata/ui-repo-copy.txtar
@@ -1,0 +1,26 @@
+# vi: set ft=conf
+
+# Test for https://github.com/charmbracelet/soft-serve/issues/769
+# The 'c' shortcut to copy the clone command should be available
+# when viewing a repository in the TUI.
+
+# start soft serve
+exec soft serve &
+ensureserverrunning SSH_PORT
+
+# create a repo and push a commit so it's not empty
+soft repo create testrepo
+git clone ssh://localhost:$SSH_PORT/testrepo repo
+mkfile ./repo/README.md '# Test'
+git -C repo add -A
+git -C repo commit -m 'init'
+git -C repo push origin HEAD
+
+# open TUI, navigate into testrepo (enter), expand help (?), wait, quit
+# key sequence: wait, enter to select repo, wait, ? to expand help, wait, quit
+ui '"    \r    ?    q"'
+cp stdout repo-view.txt
+grep 'copy clone cmd' repo-view.txt
+
+# stop the server
+[windows] stopserver


### PR DESCRIPTION
## Summary

- When viewing a repository in the TUI, pressing `c` now copies the git clone command to the clipboard
- Previously this shortcut only worked from the repository list, not inside a repo view
- Added `c copy clone cmd` to the repo view's common help bindings

## Test plan

- [x] `c copy clone cmd` appears in the repo view help (verified via TUI testscript)
- [x] Key press triggers `copyCmd` with the clone URL
- [x] Existing `c` behavior in the selection view is unchanged

Fixes charmbracelet/soft-serve#769

🤖 Generated with [Claude Code](https://claude.com/claude-code)