### PR TITLE
fix(web): return io.ErrShortWrite and handle partial Read in ReadFrom (#616)

### DIFF
--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -464,21 +464,26 @@ func (f *flushResponseWriter) ReadFrom(r io.Reader) (int64, error) {
 	var n int64
 	p := make([]byte, 1024)
 	for {
-		nRead, err := r.Read(p)
-		if err == io.EOF {
+		nRead, readErr := r.Read(p)
+		if nRead > 0 {
+			nWrite, err := f.ResponseWriter.Write(p[:nRead])
+			if err != nil {
+				return n, err
+			}
+			if nRead != nWrite {
+				return n, io.ErrShortWrite
+			}
+			n += int64(nRead)
+			// ResponseWriter must support http.Flusher to handle buffered output.
+			if err := flusher.Flush(); err != nil {
+				return n, fmt.Errorf("%w: error while flush", err)
+			}
+		}
+		if readErr == io.EOF {
 			break
 		}
-		nWrite, err := f.ResponseWriter.Write(p[:nRead])
-		if err != nil {
-			return n, err
-		}
-		if nRead != nWrite {
-			return n, err
-		}
-		n += int64(nRead)
-		// ResponseWriter must support http.Flusher to handle buffered output.
-		if err := flusher.Flush(); err != nil {
-			return n, fmt.Errorf("%w: error while flush", err)
+		if readErr != nil {
+			return n, readErr
 		}
 	}
 


### PR DESCRIPTION
## Problem

In `flushResponseWriter.ReadFrom`, two related bugs caused silent data loss in HTTP git responses:

1. When `ResponseWriter.Write` wrote fewer bytes than were read (`nRead != nWrite`), the function returned `n, err` where `err` was `nil` — hiding the short-write condition from callers.
2. When `io.Reader.Read` returned `n > 0` alongside `io.EOF` (valid per the [io.Reader contract](https://pkg.go.dev/io#Reader)), the bytes were silently dropped because the loop broke before writing them.

## Fix

Restructure the loop to mirror the pattern in `io.Copy`:
- Process any bytes returned by `Read` before inspecting the read error
- Return `io.ErrShortWrite` when the write is incomplete

## Tests

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes

Closes charmbracelet/soft-serve#616