### PR TITLE
fix(server): pre-bind listeners so port permission errors surface immediately (#645)

### DIFF
--- a/cmd/soft/serve/server.go
+++ b/cmd/soft/serve/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 
 	"charm.land/log/v2"
@@ -113,46 +114,76 @@ func (s *Server) ReloadCertificates() error {
 
 // Start starts the SSH server.
 func (s *Server) Start() error {
+	// Pre-bind all listeners before launching goroutines so that port
+	// permission errors (e.g. EACCES on privileged ports) are returned
+	// immediately instead of being swallowed by a blocked errgroup.Wait().
+	var sshListener, gitListener, httpListener, statsListener net.Listener
+	var err error
+
+	if s.Config.SSH.Enabled {
+		sshListener, err = net.Listen("tcp", s.Config.SSH.ListenAddr)
+		if err != nil {
+			return fmt.Errorf("listen ssh %s: %w", s.Config.SSH.ListenAddr, err)
+		}
+	}
+
+	if s.Config.Git.Enabled {
+		gitListener, err = net.Listen("tcp", s.Config.Git.ListenAddr)
+		if err != nil {
+			return fmt.Errorf("listen git daemon %s: %w", s.Config.Git.ListenAddr, err)
+		}
+	}
+
+	if s.Config.HTTP.Enabled {
+		httpListener, err = net.Listen("tcp", s.Config.HTTP.ListenAddr)
+		if err != nil {
+			return fmt.Errorf("listen http %s: %w", s.Config.HTTP.ListenAddr, err)
+		}
+	}
+
+	if s.Config.Stats.Enabled {
+		statsListener, err = net.Listen("tcp", s.Config.Stats.ListenAddr)
+		if err != nil {
+			return fmt.Errorf("listen stats %s: %w", s.Config.Stats.ListenAddr, err)
+		}
+	}
+
 	errg, _ := errgroup.WithContext(s.ctx)
 
-	// optionally start the SSH server
 	if s.Config.SSH.Enabled {
 		errg.Go(func() error {
 			s.logger.Print("Starting SSH server", "addr", s.Config.SSH.ListenAddr)
-			if err := s.SSHServer.ListenAndServe(); !errors.Is(err, ssh.ErrServerClosed) {
+			if err := s.SSHServer.Serve(sshListener); !errors.Is(err, ssh.ErrServerClosed) {
 				return err
 			}
 			return nil
 		})
 	}
 
-	// optionally start the git daemon
 	if s.Config.Git.Enabled {
 		errg.Go(func() error {
 			s.logger.Print("Starting Git daemon", "addr", s.Config.Git.ListenAddr)
-			if err := s.GitDaemon.ListenAndServe(); !errors.Is(err, daemon.ErrServerClosed) {
+			if err := s.GitDaemon.Serve(gitListener); !errors.Is(err, daemon.ErrServerClosed) {
 				return err
 			}
 			return nil
 		})
 	}
 
-	// optionally start the HTTP server
 	if s.Config.HTTP.Enabled {
 		errg.Go(func() error {
 			s.logger.Print("Starting HTTP server", "addr", s.Config.HTTP.ListenAddr)
-			if err := s.HTTPServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			if err := s.HTTPServer.Serve(httpListener); !errors.Is(err, http.ErrServerClosed) {
 				return err
 			}
 			return nil
 		})
 	}
 
-	// optionally start the Stats server
 	if s.Config.Stats.Enabled {
 		errg.Go(func() error {
 			s.logger.Print("Starting Stats server", "addr", s.Config.Stats.ListenAddr)
-			if err := s.StatsServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			if err := s.StatsServer.Serve(statsListener); !errors.Is(err, http.ErrServerClosed) {
 				return err
 			}
 			return nil

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"time"
 
@@ -38,6 +39,11 @@ func NewStatsServer(ctx context.Context) (*StatsServer, error) {
 // ListenAndServe starts the StatsServer.
 func (s *StatsServer) ListenAndServe() error {
 	return s.server.ListenAndServe()
+}
+
+// Serve starts the StatsServer on the given listener.
+func (s *StatsServer) Serve(l net.Listener) error {
+	return s.server.Serve(l)
 }
 
 // Shutdown gracefully shuts down the StatsServer.

--- a/pkg/web/http.go
+++ b/pkg/web/http.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"time"
 
@@ -54,6 +55,15 @@ func (s *HTTPServer) ListenAndServe() error {
 		return s.Server.ListenAndServeTLS("", "")
 	}
 	return s.Server.ListenAndServe()
+}
+
+// Serve starts the HTTP server on the given listener.
+// If TLS is configured the listener is wrapped before accepting connections.
+func (s *HTTPServer) Serve(l net.Listener) error {
+	if s.Server.TLSConfig != nil {
+		l = tls.NewListener(l, s.Server.TLSConfig)
+	}
+	return s.Server.Serve(l)
 }
 
 // Shutdown gracefully shuts down the HTTP server.


### PR DESCRIPTION
## Problem

`Start()` launched all servers inside `errgroup` goroutines. When one server failed to bind a privileged port (EACCES), the errgroup received the error but `errg.Wait()` still had to wait for the remaining goroutines to finish. Those goroutines were successfully serving their own ports and blocked in `ListenAndServe()` indefinitely — so `errg.Wait()` never returned and the error was silently swallowed. From the user's perspective soft-serve appeared to start normally, but the configured port was never bound.

## Fix

Pre-bind all TCP listeners **before** launching any goroutines. A bind failure (EACCES, EADDRINUSE, etc.) is returned immediately from `Start()` before any server accepts a single connection.

Each sub-server gains a `Serve(net.Listener)` method so it can accept a pre-bound listener:
- `SSHServer` and `GitDaemon` already had `Serve(net.Listener)`
- Added `HTTPServer.Serve` — wraps the listener with TLS when configured
- Added `StatsServer.Serve`

## Tests

- [x] `go build ./...` passes
- [x] `go test ./...` passes (33 testscript cases, 0 failures)

Closes charmbracelet/soft-serve#645