### PR TITLE
fix(ui): use path instead of filepath for git tree paths on Windows (#681)

### DIFF
--- a/pkg/ui/pages/repo/files.go
+++ b/pkg/ui/pages/repo/files.go
@@ -3,7 +3,7 @@ package repo
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -253,7 +253,7 @@ func (f *Files) Update(msg tea.Msg) (common.Model, tea.Cmd) {
 		switch sel := msg.IdentifiableItem.(type) {
 		case FileItem:
 			f.currentItem = &sel
-			f.path = filepath.Join(f.path, sel.entry.Name())
+			f.path = path.Join(f.path, sel.entry.Name())
 			if sel.entry.IsTree() {
 				cmds = append(cmds, f.selectTreeCmd)
 			} else {
@@ -458,19 +458,19 @@ func (f *Files) selectFileCmd() tea.Msg {
 		if !bin {
 			bin, err = fi.IsBinary()
 			if err != nil {
-				f.path = filepath.Dir(f.path)
+				f.path = path.Dir(f.path)
 				return common.ErrorMsg(err)
 			}
 		}
 
 		if bin {
-			f.path = filepath.Dir(f.path)
+			f.path = path.Dir(f.path)
 			return common.ErrorMsg(errBinaryFile)
 		}
 
 		c, err := fi.Bytes()
 		if err != nil {
-			f.path = filepath.Dir(f.path)
+			f.path = path.Dir(f.path)
 			return common.ErrorMsg(err)
 		}
 
@@ -527,7 +527,7 @@ func renderBlame(c common.Common, f *FileItem, b *gitm.Blame) string {
 }
 
 func (f *Files) deselectItemCmd() tea.Cmd {
-	f.path = filepath.Dir(f.path)
+	f.path = path.Dir(f.path)
 	index := 0
 	if len(f.lastSelected) > 0 {
 		index = f.lastSelected[len(f.lastSelected)-1]

--- a/pkg/ui/pages/repo/readme.go
+++ b/pkg/ui/pages/repo/readme.go
@@ -1,7 +1,7 @@
 package repo
 
 import (
-	"path/filepath"
+	"path"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
@@ -147,7 +147,7 @@ func (r *Readme) SpinnerID() int {
 
 // StatusBarValue implements statusbar.StatusBar.
 func (r *Readme) StatusBarValue() string {
-	dir := filepath.Dir(r.readmePath)
+	dir := path.Dir(r.readmePath)
 	if dir == "." || dir == "" {
 		return " "
 	}


### PR DESCRIPTION
## Problem

The TUI Files tab uses `filepath.Join` and `filepath.Dir` to build the current directory path. On Windows, `filepath.Join` uses `\` as the separator. When this backslash-separated path is passed to `repo.TreePath(ref, path)`, git can't find the tree entry (git paths always use `/`), and the navigation silently reverts to the parent directory on each Enter press.

This explains the reported behavior:
- First level (`dot_config`) works because there is no separator in a single-component path
- Entering `bat` builds `dot_config\bat` (backslash) → `TreePath` fails → path reverts to `dot_config` → looks like nothing happened
- Second Enter attempt shows partial path in status bar before reverting again

The same issue affects `readme.go`'s `StatusBarValue` which uses `filepath.Dir` to show the readme directory.

## Fix

Replace `path/filepath` with `path` (the slash-only standard library package) in `files.go` and `readme.go`. The `path` package always uses forward slashes, matching what git expects.

## Tests

- [x] `go build ./...` passes
- [x] `go test ./...` passes (33 testscript cases, 0 failures)

Closes charmbracelet/soft-serve#681