### PR TITLE
fix(ssh): create host key directory before generating key

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -95,8 +95,10 @@ func NewSSHServer(ctx context.Context) (*SSHServer, error) {
 	// in-memory key on every restart — causing host-key-changed errors for
 	// clients on each restart.
 	if cfg.SSH.KeyPath != "" {
-		if err := os.MkdirAll(filepath.Dir(cfg.SSH.KeyPath), 0o700); err != nil {
-			return nil, fmt.Errorf("create host key directory: %w", err)
+		if dir := filepath.Dir(cfg.SSH.KeyPath); dir != "." {
+			if err := os.MkdirAll(dir, 0o700); err != nil {
+				return nil, fmt.Errorf("create host key directory: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

When \`ssh.key_path\` points to a directory that does not yet exist,
\`keygen.New\` inside \`wish.WithHostKeyPath\` fails silently. wish then
falls back to a new ephemeral in-memory host key, so the server's SSH
identity changes on every restart — triggering host-key-changed errors
for all clients.

Add \`os.MkdirAll\` for the key file's parent directory before building
the SSH server options. This ensures any custom \`key_path\` whose
parent directory does not already exist is created on first start,
allowing \`keygen.New\` to write the key and persist it across restarts.

Closes #779