### PR TITLE
fix(ssh): validate access tokens in keyboard-interactive auth

### DIFF
--- a/pkg/ssh/middleware.go
+++ b/pkg/ssh/middleware.go
@@ -67,7 +67,11 @@ func AuthenticationMiddleware(sh ssh.Handler) ssh.Handler {
 		// context key (tokenAuthUserIDKey) set during keyboard-interactive auth.
 		var user proto.User
 		if pk != nil {
-			user, _ = be.UserByPublicKey(ctx, pk)
+			if u, err := be.UserByPublicKey(ctx, pk); err != nil {
+				log.FromContext(ctx).Debug("public key lookup failed", "err", err)
+			} else {
+				user = u
+			}
 		} else if tokenID, ok := ctx.Value(tokenAuthUserIDKey{}).(int64); ok {
 			if u, err := be.UserByID(ctx, tokenID); err != nil {
 				log.FromContext(ctx).Warn("failed to resolve token-auth user", "id", tokenID, "err", err)

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -181,6 +181,7 @@ func (s *SSHServer) PublicKeyHandler(ctx ssh.Context, pk ssh.PublicKey) (allowed
 
 	// Set the public key fingerprint to be used for authentication.
 	perms.Extensions["pubkey-fp"] = gossh.FingerprintSHA256(pk)
+	ctx.SetValue(ssh.ContextKeyPermissions, perms)
 
 	return
 }
@@ -204,7 +205,11 @@ func (s *SSHServer) KeyboardInteractiveHandler(ctx ssh.Context, challenge gossh.
 			// We intentionally do NOT use perms.Extensions here — certificate
 			// extensions from gossh are merged into the same map, so a string
 			// key can be injected by a client presenting a crafted certificate.
+			//
+			// Clear pubkey-fp so AuthenticationMiddleware's fingerprint guard
+			// does not reject this keyless token-auth session.
 			perms.Extensions["pubkey-fp"] = ""
+			ctx.SetValue(ssh.ContextKeyPermissions, perms)
 			ctx.SetValue(tokenAuthUserIDKey{}, user.ID())
 			keyboardInteractiveCounter.WithLabelValues("true").Inc()
 			s.logger.Info("keyboard-interactive token auth succeeded", "username", user.Username())


### PR DESCRIPTION
## Summary

Ports the fix for charmbracelet/soft-serve#800: access tokens don't provide authentication.

**Root cause**: `KeyboardInteractiveHandler` discarded the challenge (`_` parameter) and only checked `AllowKeyless`. Two consequences:
1. Tokens were never validated — any string or no string produced the same outcome
2. Token-authenticated sessions had no user identity, so collaborator-based repo access was silently bypassed

**Fix**:
- Prompt for an access token via the SSH keyboard-interactive challenge
- Validate via `UserByAccessToken`; on success store the user ID in `perms.Extensions[tokenUserExtKey]` and return `true` regardless of `AllowKeyless`
- Fall back to `AllowKeyless` when no valid token is provided (preserving existing behaviour for keyless clients)
- Update `AuthenticationMiddleware` to resolve user by stored token user ID when no public key is present

## Changes

`pkg/ssh/ssh.go`:
- Add `tokenUserExtKey` constant
- Move `ctx.SetValue` into `initializePermissions`
- Rewrite `KeyboardInteractiveHandler` to validate token via challenge

`pkg/ssh/middleware.go`:
- Resolve user from `tokenUserExtKey` extension when no public key is present

## Test plan

- [ ] Create user + access token: `ssh localhost token create mytoken`
- [ ] Set AllowKeyless=false
- [ ] Connect with valid token via keyboard-interactive → accepted, user identity resolved
- [ ] Connect with invalid token → rejected
- [ ] Connect with no token → rejected (AllowKeyless=false)
- [ ] Set AllowKeyless=true → keyless (no token) clients still accepted
- [ ] Private repo shared as collaborator → appears in list for token-authenticated session

Closes charmbracelet/soft-serve#800