### PR TITLE
fix(ssh): downgrade spurious signal-killed log to debug on client disconnect

### DIFF
--- a/pkg/ssh/cmd/git.go
+++ b/pkg/ssh/cmd/git.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -293,11 +294,14 @@ func gitRunE(cmd *cobra.Command, args []string) error {
 		} else if err != nil {
 			// When the client disconnects early (e.g. Flux Source controller
 			// closes the connection after receiving ref advertisements), the
-			// context is cancelled and the git process is killed with SIGKILL.
-			// This produces a "signal: killed" error that is normal and
-			// expected — log it at debug level, not error.
-			if ctx.Err() != nil {
-				logger.Debug("git service ended on client disconnect", "service", service, "repo", name)
+			// SSH session context is cancelled and exec.CommandContext kills
+			// the git subprocess with SIGKILL, producing "signal: killed".
+			// That is normal — log it at debug level, not error.
+			// Use context.Canceled specifically: context.DeadlineExceeded
+			// means a server-side timeout fired, which is still worth an
+			// ERROR so operators can tune their timeout settings.
+			if ctx.Err() == context.Canceled {
+				logger.Debug("git service ended on client disconnect", "service", service, "err", err, "repo", name)
 			} else {
 				logger.Error("failed to handle git service", "service", service, "err", err, "repo", name)
 			}


### PR DESCRIPTION
## Summary

When a git client (e.g. Flux Source controller) disconnects early during
`git-upload-pack`, the server's context is cancelled and Go's
`exec.CommandContext` kills the git subprocess with SIGKILL. The resulting
`"signal: killed"` error was being logged unconditionally at **ERROR** level,
flooding operator dashboards with false alarms for completely normal behavior.

- Check `ctx.Err() != nil` before choosing the log level for upload-pack/upload-archive errors
- If context is already cancelled → client disconnected → log at **DEBUG**
- If context is still alive → genuine server fault → keep **ERROR**

## Test plan

- [ ] Build passes: `go vet ./...`
- [ ] Start soft-serve and run `git ls-remote ssh://localhost:23231/repo` — no ERROR log emitted
- [ ] Simulate a real error (e.g. corrupt repo) — ERROR log still emitted

Closes #807

## References

Upstream: charmbracelet/soft-serve#560