### PR TITLE
chore: merge dev into main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,235 @@
+# AGENTS.md — Soft Serve
+
+> AI agent guide for [Soft Serve](https://github.com/charmbracelet/soft-serve), a self-hosted Git server with SSH, HTTP, and native git protocol support, plus a built-in TUI.
+
+## Project Identity
+
+- **Module:** `github.com/charmbracelet/soft-serve`
+- **Language:** Go 1.25+
+- **Binary:** `soft` (entry point: `cmd/soft/main.go`)
+- **Database:** SQLite (default) or PostgreSQL, via `jmoiron/sqlx`
+- **CLI framework:** `spf13/cobra` (used for both the main CLI and SSH subcommands)
+- **SSH framework:** `charm.land/wish/v2`
+- **TUI framework:** `charm.land/bubbletea/v2` + `lipgloss/v2` + `glamour/v2`
+- **HTTP router:** `gorilla/mux`
+- **Config:** YAML file (`$SOFT_SERVE_DATA_PATH/config.yaml`) + env vars (`SOFT_SERVE_*` prefix)
+
+## Architecture Overview
+
+Soft Serve runs **four concurrent servers** via `errgroup`:
+
+| Server | Package | Protocol | Purpose |
+|--------|---------|----------|---------|
+| SSH | `pkg/ssh/` | SSH | Git push/pull, interactive TUI, admin CLI commands |
+| HTTP | `pkg/web/` | HTTP/HTTPS | Git smart HTTP, LFS API, go-get meta, health check |
+| Git Daemon | `pkg/daemon/` | Native git (TCP) | Read-only anonymous git access |
+| Stats | `pkg/stats/` | HTTP | Prometheus `/metrics` endpoint |
+
+### Layered Design
+
+```
+cmd/soft/         → CLI entry points (serve, browse, admin, hook)
+pkg/ssh/          → SSH server + middleware + command dispatch
+pkg/web/          → HTTP server + middleware + routes
+pkg/daemon/       → Git daemon (raw TCP, pktline)
+pkg/backend/      → Central business logic orchestrator
+pkg/store/        → Data store interface (7 sub-interfaces)
+pkg/store/database/ → SQL implementation of Store
+pkg/db/           → Database layer (open, migrate, models)
+pkg/proto/        → Core domain interfaces (User, Repository)
+pkg/access/       → Access level enum (NoAccess → Admin)
+pkg/git/          → Git service handlers (upload-pack, receive-pack)
+pkg/config/       → Configuration parsing (YAML + env)
+pkg/ui/           → TUI components (Bubble Tea models)
+```
+
+### Canonical Data Flow
+
+```
+Transport layer (SSH/HTTP/daemon)
+  → Middleware (context injection, auth, logging)
+    → Command/Route dispatch
+      → Backend (business logic)
+        → Store (data access)
+          → Database (SQLite/PostgreSQL)
+```
+
+## Directory Structure
+
+```
+cmd/
+  soft/main.go              — Binary entry point
+  soft/serve/               — `soft serve` command (starts all servers)
+  soft/admin/               — `soft admin` SSH admin commands
+  soft/browse/              — `soft browse` TUI browser
+  soft/hook/                — `soft hook` git hook handler
+  cmd.go                    — Shared InitBackendContext / CloseDBContext helpers
+git/                        — Low-level git operations (repo, commit, tree, tag, refs)
+pkg/
+  access/                   — AccessLevel enum (NoAccess, ReadOnly, ReadWrite, Admin)
+  backend/                  — Central Backend struct: users, repos, auth, LFS, webhooks, cache
+  config/                   — Config struct (YAML + env, SOFT_SERVE_* prefix)
+  cron/                     — Cron scheduler wrapper (robfig/cron)
+  daemon/                   — Git daemon server (TCP, native git protocol)
+  db/                       — Database abstraction (open, migrations, models)
+    migrate/                — SQL migration files (SQLite + PostgreSQL variants)
+    models/                 — DB model structs
+  git/                      — Git service handlers (upload-pack, receive-pack, LFS transfer)
+  hooks/                    — Git hook generation and interface
+  jobs/                     — Cron job definitions (mirror pull)
+  jwk/                      — JSON Web Key support
+  lfs/                      — Git LFS protocol (client, pointers, scanner, transfers)
+  log/                      — Logger setup
+  proto/                    — Core interfaces (Repository, User, AccessToken, errors)
+  ssh/                      — SSH server, middleware, session handler
+    cmd/                    — 27 SSH subcommands (git, repo, user, token, webhook, settings)
+  sshutils/                 — SSH utility functions
+  ssrf/                     — SSRF protection for outbound requests
+  stats/                    — Prometheus metrics server
+  storage/                  — Storage abstraction (file storage for LFS)
+  store/                    — Store interface (composite of 7 sub-interfaces)
+    database/               — SQL-backed Store implementation
+  sync/                     — Sync utilities
+  task/                     — Async task manager
+  ui/                       — Bubble Tea TUI components
+    common/                 — Shared TUI state/styles
+    components/             — Reusable widgets (code, footer, header, selector, statusbar, tabs, viewport)
+    pages/                  — TUI pages (repo list, repo detail)
+    styles/                 — TUI styling
+  utils/                    — General utilities (SanitizeRepo, ValidateRepo)
+  version/                  — Version info
+  web/                      — HTTP server (git smart HTTP, LFS API, auth, health)
+  webhook/                  — Webhook event system (push, branch/tag, repo, collaborator)
+testscript/                 — Integration tests (testscript framework)
+migrations/                 — Goose SQL migrations
+```
+
+## Key Patterns
+
+### Context-Based Dependency Injection
+
+All major dependencies are threaded through `context.Context` with typed keys:
+
+```go
+// Injecting
+ctx = config.WithContext(ctx, cfg)
+ctx = backend.WithContext(ctx, be)
+
+// Extracting
+cfg := config.FromContext(ctx)
+be := backend.FromContext(ctx)
+```
+
+Shared bootstrap in `cmd/cmd.go:InitBackendContext` (used as Cobra `PersistentPreRunE`).
+
+### Backend as Central Orchestrator
+
+`pkg/backend/backend.go:Backend` is the single entry point for all business logic. It wraps the Store and provides methods for repos, users, auth, LFS, webhooks, settings, and caching. Handlers and commands call Backend methods — never the Store directly.
+
+### Store Interface (Composite)
+
+`pkg/store/store.go:Store` aggregates 7 sub-interfaces:
+
+- `RepositoryStore` — repo CRUD
+- `UserStore` — user CRUD
+- `CollaboratorStore` — repo collaborators
+- `SettingStore` — server settings
+- `LFSStore` — LFS objects/locks
+- `AccessTokenStore` — API tokens
+- `WebhookStore` — webhook management
+
+Single SQL implementation in `pkg/store/database/`.
+
+### Authentication
+
+**SSH:** Public key verification → `be.UserByPublicKey()`. Keyboard-interactive as keyless fallback.
+
+**HTTP:** Three schemes via `Authorization` header:
+- `Basic` — username/password (bcrypt) or username/access-token
+- `Token` — access token directly (`ss_` prefixed, SHA256 hashed)
+- `Bearer` — JWT (Ed25519 signed, scoped to repo)
+
+### Authorization
+
+Four levels in `pkg/access/access.go`:
+- `NoAccess` (0) — denied
+- `ReadOnlyAccess` (1) — clone/fetch
+- `ReadWriteAccess` (2) — push, LFS locks
+- `AdminAccess` (3) — server management
+
+### SSH Command Dispatch
+
+Non-PTY SSH sessions go through `CommandMiddleware` which builds a Cobra command tree from `pkg/ssh/cmd/`. The same `cobra.Command` pattern used for the main CLI is reused for SSH commands.
+
+PTY sessions launch the Bubble Tea TUI via `SessionHandler`.
+
+### Git Operations
+
+Git push/pull is handled by shelling out to the `git` binary (not pure Go) via `pkg/git/service.go:gitServiceHandler`. Environment variables pass context (repo name, username, public key) to git hooks.
+
+### Webhook System
+
+Events defined in `pkg/webhook/`: push, branch create/delete, tag create/delete, repository create/delete, collaborator add/remove. Delivery via HTTP POST with HMAC-SHA256 signatures. SSRF protection in `pkg/ssrf/`.
+
+## Build & Test
+
+```bash
+# Build
+go build ./cmd/soft
+
+# Run all tests
+go test ./...
+
+# Run integration tests
+go test ./testscript/...
+
+# Run specific test
+go test -run TestName ./pkg/backend/...
+```
+
+### Test Framework
+
+- Unit tests: standard Go `testing` + `matryer/is` for assertions
+- Integration tests: `rogpeppe/go-internal/testscript` (script-driven, in `testscript/`)
+- Test helpers in `pkg/test/`
+
+## Database
+
+- **Drivers:** SQLite (`modernc.org/sqlite`, pure Go) and PostgreSQL (`lib/pq`)
+- **Access:** `jmoiron/sqlx` with raw SQL queries, `$1`/`$2` placeholders
+- **Migrations:** Go-embedded SQL files in `pkg/db/migrate/`, separate `.up.sql`/`.down.sql` per driver
+- **Models:** `pkg/db/models/`
+- **Transactions:** `db.TransactionContext` helper
+
+## Configuration
+
+Loaded from `$SOFT_SERVE_DATA_PATH/config.yaml` with env var overrides (`SOFT_SERVE_*` prefix). Parsed via `caarlos0/env`. Key config sections:
+
+- `SSH` — listen addr, max timeout, key path
+- `HTTP` — listen addr, TLS cert/key, public URL
+- `Git` — listen addr, max connections, max timeout
+- `Stats` — listen addr
+- `LFS` — enabled flag
+- `DB` — driver (sqlite/postgres), data source
+
+## Metrics
+
+Prometheus metrics throughout the codebase via `promauto`. Exposed at Stats server `/metrics`. Covers SSH connections, HTTP requests, git operations, TUI sessions, LFS transfers.
+
+## Known TODOs
+
+- `pkg/backend/backend.go` — proper caching interface (currently basic in-memory)
+- `pkg/backend/lfs.go` — S3 storage support for LFS
+- `pkg/lfs/ssh_client.go` — Git LFS SSH client (placeholder)
+- `pkg/backend/hooks.go` — async hook execution
+- `pkg/backend/user.go` — user repository ownership
+
+## Common Pitfalls
+
+1. **Never edit `*_templ.go` files** — they are generated. Edit `.templ` sources only.
+2. **Context is king** — all dependencies flow through `context.Context`. Use `FromContext` accessors.
+3. **Backend, not Store** — handlers call `Backend` methods, never `Store` directly.
+4. **Git binary, not go-git** — push/pull shells out to `git`. `go-git` is used for read operations (log, tree, diff).
+5. **Dual DB support** — SQL must work on both SQLite and PostgreSQL. Test with both if modifying queries.
+6. **SSH commands are Cobra commands** — same pattern as CLI, dispatched in `CommandMiddleware`.
+7. **Access levels gate everything** — check `AccessLevel` before any repo operation.

--- a/cmd/soft/serve/serve.go
+++ b/cmd/soft/serve/serve.go
@@ -12,7 +12,9 @@ import (
 	"syscall"
 	"time"
 
+	"charm.land/log/v2"
 	"github.com/charmbracelet/soft-serve/cmd"
+	"github.com/charmbracelet/soft-serve/pkg/access"
 	"github.com/charmbracelet/soft-serve/pkg/backend"
 	"github.com/charmbracelet/soft-serve/pkg/config"
 	"github.com/charmbracelet/soft-serve/pkg/db"
@@ -68,6 +70,26 @@ var (
 			db := db.FromContext(ctx)
 			if err := migrate.Migrate(ctx, db); err != nil {
 				return fmt.Errorf("migration error: %w", err)
+			}
+
+			// Apply config-driven settings so operators can automate
+			// server setup without a post-start SSH session.
+			{
+				cfgCtx := config.FromContext(ctx)
+				be := backend.FromContext(ctx)
+				logger := log.FromContext(ctx).WithPrefix("server")
+				if cfgCtx.AnonAccess != "" {
+					if err := be.SetAnonAccess(ctx, access.ParseAccessLevel(cfgCtx.AnonAccess)); err != nil {
+						return fmt.Errorf("set anon_access: %w", err)
+					}
+					logger.Debug("applied anon_access from config", "level", cfgCtx.AnonAccess)
+				}
+				if cfgCtx.AllowKeyless != nil {
+					if err := be.SetAllowKeyless(ctx, *cfgCtx.AllowKeyless); err != nil {
+						return fmt.Errorf("set allow_keyless: %w", err)
+					}
+					logger.Debug("applied allow_keyless from config", "value", *cfgCtx.AllowKeyless)
+				}
 			}
 
 			s, err := NewServer(ctx)

--- a/git/utils.go
+++ b/git/utils.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/gobwas/glob"
@@ -10,7 +11,7 @@ import (
 // LatestFile returns the contents of the first file at the specified path pattern in the repository and its file path.
 func LatestFile(repo *Repository, ref *Reference, pattern string) (string, string, error) {
 	g := glob.MustCompile(pattern)
-	dir := filepath.Dir(pattern)
+	dir := path.Dir(pattern)
 	if ref == nil {
 		head, err := repo.HEAD()
 		if err != nil {
@@ -28,7 +29,7 @@ func LatestFile(repo *Repository, ref *Reference, pattern string) (string, strin
 	}
 	for _, e := range ents {
 		te := e
-		fp := filepath.Join(dir, te.Name())
+		fp := path.Join(dir, te.Name())
 		if te.IsTree() {
 			continue
 		}

--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -65,10 +65,23 @@ func (d *Backend) CreateRepository(ctx context.Context, name string, user proto.
 			return err
 		}
 
-		_, err := git.Init(rp, true)
+		rr, err := git.Init(rp, true)
 		if err != nil {
 			d.logger.Debug("failed to create repository", "err", err)
 			return err
+		}
+
+		if user != nil && user.Username() != "" {
+			rcfg, err := rr.Config()
+			if err != nil {
+				d.logger.Error("failed to get repository config", "repo", name, "err", err)
+				return err
+			}
+			rcfg.Section("gitweb").SetOption("owner", user.Username())
+			if err := rr.SetConfig(rcfg); err != nil {
+				d.logger.Error("failed to set gitweb.owner", "repo", name, "err", err)
+				return err
+			}
 		}
 
 		if err := os.WriteFile(filepath.Join(rp, "description"), []byte(opts.Description), fs.ModePerm); err != nil {

--- a/pkg/backend/user.go
+++ b/pkg/backend/user.go
@@ -23,24 +23,6 @@ func (d *Backend) AccessLevel(ctx context.Context, repo string, username string)
 	return d.AccessLevelForUser(ctx, repo, user)
 }
 
-// AccessLevelByPublicKey returns the access level of a user's public key for a repository.
-//
-// It implements backend.Backend.
-func (d *Backend) AccessLevelByPublicKey(ctx context.Context, repo string, pk ssh.PublicKey) access.AccessLevel {
-	for _, k := range d.cfg.AdminKeys() {
-		if sshutils.KeysEqual(pk, k) {
-			return access.AdminAccess
-		}
-	}
-
-	user, _ := d.UserByPublicKey(ctx, pk)
-	if user != nil {
-		return d.AccessLevel(ctx, repo, user.Username())
-	}
-
-	return d.AccessLevel(ctx, repo, "")
-}
-
 // AccessLevelForUser returns the access level of a user for a repository.
 // TODO: user repository ownership
 func (d *Backend) AccessLevelForUser(ctx context.Context, repo string, user proto.User) access.AccessLevel {

--- a/pkg/backend/utils.go
+++ b/pkg/backend/utils.go
@@ -1,6 +1,8 @@
 package backend
 
 import (
+	"errors"
+
 	"github.com/charmbracelet/soft-serve/git"
 	"github.com/charmbracelet/soft-serve/pkg/proto"
 )
@@ -15,9 +17,38 @@ func LatestFile(r proto.Repository, ref *git.Reference, pattern string) (string,
 	return git.LatestFile(repo, ref, pattern)
 }
 
+// readmePatterns is the ordered list of glob patterns used to find a README.
+// Root-level patterns are checked first; subdirectory paths are fallbacks,
+// matching GitHub's README discovery behavior.
+var readmePatterns = []string{
+	"[rR][eE][aA][dD][mM][eE]",
+	"[rR][eE][aA][dD][mM][eE].*",
+	"docs/[rR][eE][aA][dD][mM][eE]",
+	"docs/[rR][eE][aA][dD][mM][eE].*",
+	".github/[rR][eE][aA][dD][mM][eE]",
+	".github/[rR][eE][aA][dD][mM][eE].*",
+	".gitlab/[rR][eE][aA][dD][mM][eE]",
+	".gitlab/[rR][eE][aA][dD][mM][eE].*",
+}
+
 // Readme returns the repository's README.
+// It checks the repository root first, then falls back to docs/, .github/,
+// and .gitlab/ subdirectories.
+// When no README is found in any location, it returns ("", "", nil).
+// Callers should check whether path is empty to detect a missing README.
 func Readme(r proto.Repository, ref *git.Reference) (readme string, path string, err error) {
-	pattern := "[rR][eE][aA][dD][mM][eE]*"
-	readme, path, err = LatestFile(r, ref, pattern)
-	return
+	for _, pattern := range readmePatterns {
+		readme, path, err = LatestFile(r, ref, pattern)
+		if err == nil {
+			return
+		}
+		if !errors.Is(err, git.ErrFileNotFound) &&
+			!errors.Is(err, git.ErrRevisionNotExist) &&
+			!errors.Is(err, git.ErrReferenceNotExist) {
+			return
+		}
+	}
+	// No README found in any location; return a clean sentinel rather than
+	// leaking the error from the last pattern tried.
+	return "", "", nil
 }

--- a/pkg/backend/utils_test.go
+++ b/pkg/backend/utils_test.go
@@ -1,0 +1,213 @@
+package backend
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/soft-serve/git"
+)
+
+// stubRepo implements proto.Repository backed by a real on-disk git repo.
+type stubRepo struct {
+	path string
+}
+
+func (s *stubRepo) ID() int64            { return 0 }
+func (s *stubRepo) Name() string         { return "stub" }
+func (s *stubRepo) ProjectName() string  { return "stub" }
+func (s *stubRepo) Description() string  { return "" }
+func (s *stubRepo) IsPrivate() bool      { return false }
+func (s *stubRepo) IsMirror() bool       { return false }
+func (s *stubRepo) IsHidden() bool       { return false }
+func (s *stubRepo) UserID() int64        { return 0 }
+func (s *stubRepo) CreatedAt() time.Time { return time.Time{} }
+func (s *stubRepo) UpdatedAt() time.Time { return time.Time{} }
+func (s *stubRepo) Open() (*git.Repository, error) {
+	return git.Open(s.path)
+}
+
+// initTestRepo creates a non-bare git repo in a temp dir, commits the given
+// files (map of relative path → content), and returns the path.
+func initTestRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	repo, err := git.Init(dir, false)
+	if err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	_ = repo
+
+	for rel, content := range files {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write file %s: %v", rel, err)
+		}
+	}
+
+	// git add -A && git commit
+	cmd := func(args ...string) {
+		t.Helper()
+		c := git.NewCommand(args...)
+		if _, err := c.RunInDir(dir); err != nil {
+			t.Fatalf("git %v: %v", args, err)
+		}
+	}
+	cmd("add", "-A")
+	cmd("-c", "user.email=test@test.com", "-c", "user.name=Test", "commit", "-m", "init")
+
+	return dir
+}
+
+func TestReadme_Root(t *testing.T) {
+	dir := initTestRepo(t, map[string]string{
+		"README.md": "# Root Readme",
+	})
+	repo := &stubRepo{path: dir}
+	content, path, err := Readme(repo, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "README.md" {
+		t.Errorf("expected path README.md, got %q", path)
+	}
+	if content != "# Root Readme" {
+		t.Errorf("unexpected content: %q", content)
+	}
+}
+
+func TestReadme_DocsSubdir(t *testing.T) {
+	// No root README; only docs/README.md
+	dir := initTestRepo(t, map[string]string{
+		"main.go":        "package main",
+		"docs/README.md": "# Docs Readme",
+	})
+	repo := &stubRepo{path: dir}
+	content, path, err := Readme(repo, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "docs/README.md" {
+		t.Errorf("expected path docs/README.md, got %q", path)
+	}
+	if content != "# Docs Readme" {
+		t.Errorf("unexpected content: %q", content)
+	}
+}
+
+func TestReadme_GithubSubdir(t *testing.T) {
+	// No root README; only .github/README.md
+	dir := initTestRepo(t, map[string]string{
+		"main.go":           "package main",
+		".github/README.md": "# GitHub Readme",
+	})
+	repo := &stubRepo{path: dir}
+	content, path, err := Readme(repo, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != ".github/README.md" {
+		t.Errorf("expected path .github/README.md, got %q", path)
+	}
+	if content != "# GitHub Readme" {
+		t.Errorf("unexpected content: %q", content)
+	}
+}
+
+func TestReadme_GitlabSubdir(t *testing.T) {
+	// No root README; only .gitlab/README.md
+	dir := initTestRepo(t, map[string]string{
+		"main.go":           "package main",
+		".gitlab/README.md": "# GitLab Readme",
+	})
+	repo := &stubRepo{path: dir}
+	content, path, err := Readme(repo, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != ".gitlab/README.md" {
+		t.Errorf("expected path .gitlab/README.md, got %q", path)
+	}
+	if content != "# GitLab Readme" {
+		t.Errorf("unexpected content: %q", content)
+	}
+}
+
+func TestReadme_RootTakesPrecedence(t *testing.T) {
+	// Both root and docs have a README; root should win
+	dir := initTestRepo(t, map[string]string{
+		"README.md":      "# Root Readme",
+		"docs/README.md": "# Docs Readme",
+	})
+	repo := &stubRepo{path: dir}
+	_, path, err := Readme(repo, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "README.md" {
+		t.Errorf("expected root README.md to take precedence, got %q", path)
+	}
+}
+
+func TestReadme_NotFound(t *testing.T) {
+	dir := initTestRepo(t, map[string]string{
+		"main.go": "package main",
+	})
+	repo := &stubRepo{path: dir}
+	content, path, err := Readme(repo, nil)
+	if err != nil {
+		t.Fatalf("unexpected error when no readme exists: %v", err)
+	}
+	if path != "" || content != "" {
+		t.Errorf("expected empty path and content when no readme exists, got content=%q path=%q", content, path)
+	}
+}
+
+// initBareTestRepo creates a bare git repo in a temp dir by initialising a
+// non-bare repo, committing the given files, and then cloning it as bare.
+func initBareTestRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	src := initTestRepo(t, files)
+	bareDir := t.TempDir()
+	c := git.NewCommand("clone", "--bare", src, bareDir)
+	if _, err := c.Run(); err != nil {
+		t.Fatalf("git clone --bare: %v", err)
+	}
+	return bareDir
+}
+
+func TestReadme_BareRepo_Root(t *testing.T) {
+	dir := initBareTestRepo(t, map[string]string{
+		"README.md": "# Bare Readme",
+	})
+	repo := &stubRepo{path: dir}
+	content, path, err := Readme(repo, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "README.md" {
+		t.Errorf("expected path README.md, got %q", path)
+	}
+	if content != "# Bare Readme" {
+		t.Errorf("unexpected content: %q", content)
+	}
+}
+
+func TestReadme_BareRepo_NotFound(t *testing.T) {
+	dir := initBareTestRepo(t, map[string]string{
+		"main.go": "package main",
+	})
+	repo := &stubRepo{path: dir}
+	content, path, err := Readme(repo, nil)
+	if err != nil {
+		t.Fatalf("unexpected error when no readme exists in bare repo: %v", err)
+	}
+	if path != "" || content != "" {
+		t.Errorf("expected empty result for bare repo with no readme, got content=%q path=%q", content, path)
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/caarlos0/env/v11"
+	"github.com/charmbracelet/soft-serve/pkg/access"
 	"github.com/charmbracelet/soft-serve/pkg/sshutils"
 	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v3"
@@ -171,6 +172,16 @@ type Config struct {
 	// InitialAdminKeys is a list of public keys that will be added to the list of admins.
 	InitialAdminKeys []string `env:"INITIAL_ADMIN_KEYS" envSeparator:"\n" yaml:"initial_admin_keys"`
 
+	// AnonAccess is the anonymous access level applied on startup.
+	// Valid values: "no-access", "read-only", "read-write", "admin-access".
+	// Leave empty to keep the value stored in the database.
+	AnonAccess string `env:"ANON_ACCESS" yaml:"anon_access"`
+
+	// AllowKeyless controls whether keyless (keyboard-interactive) access is
+	// allowed. When set, this overrides the value stored in the database on
+	// every startup.  Leave unset to keep the database value.
+	AllowKeyless *bool `env:"ALLOW_KEYLESS" yaml:"allow_keyless"`
+
 	// DataPath is the path to the directory where Soft Serve will store its data.
 	DataPath string `env:"DATA_PATH" yaml:"-"`
 }
@@ -190,6 +201,7 @@ func (c *Config) Environ() []string {
 		fmt.Sprintf("SOFT_SERVE_DATA_PATH=%s", c.DataPath),
 		fmt.Sprintf("SOFT_SERVE_NAME=%s", c.Name),
 		fmt.Sprintf("SOFT_SERVE_INITIAL_ADMIN_KEYS=%s", strings.Join(c.InitialAdminKeys, "\n")),
+		fmt.Sprintf("SOFT_SERVE_ANON_ACCESS=%s", c.AnonAccess),
 		fmt.Sprintf("SOFT_SERVE_SSH_ENABLED=%t", c.SSH.Enabled),
 		fmt.Sprintf("SOFT_SERVE_SSH_LISTEN_ADDR=%s", c.SSH.ListenAddr),
 		fmt.Sprintf("SOFT_SERVE_SSH_PUBLIC_URL=%s", c.SSH.PublicURL),
@@ -442,6 +454,21 @@ func (c *Config) Validate() error {
 	}
 
 	c.InitialAdminKeys = pks
+
+	if c.AnonAccess != "" {
+		level := access.ParseAccessLevel(c.AnonAccess)
+		// ParseAccessLevel returns NoAccess for unknown strings, but "no-access"
+		// is also a valid explicit value, so check by re-serialising.
+		if level.String() != c.AnonAccess {
+			return fmt.Errorf("invalid anon_access %q: must be one of %s, %s, %s, %s",
+				c.AnonAccess,
+				access.NoAccess.String(),
+				access.ReadOnlyAccess.String(),
+				access.ReadWriteAccess.String(),
+				access.AdminAccess.String(),
+			)
+		}
+	}
 
 	c.HTTP.CORS.AllowedOrigins = append([]string{c.HTTP.PublicURL}, c.HTTP.CORS.AllowedOrigins...)
 

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -147,6 +147,17 @@ jobs:
 # Additional admin keys.
 #initial_admin_keys:
 #  - "ssh-rsa AAAAB3NzaC1yc2..."
+
+# Anonymous access level applied on every startup.
+# Overrides the value stored in the database when set.
+# Valid values: no-access, read-only, read-write, admin-access.
+# Leave commented out to preserve the database value.
+#anon_access: read-only
+
+# Whether keyless (keyboard-interactive) access is allowed.
+# Overrides the value stored in the database when set.
+# Leave commented out to preserve the database value.
+#allow_keyless: true
 `))
 
 func newConfigFile(cfg *Config) string {

--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"charm.land/log/v2"
 )
@@ -57,8 +58,27 @@ func (s Service) Handler(ctx context.Context, cmd ServiceCommand) error {
 type ServiceHandler func(ctx context.Context, cmd ServiceCommand) error
 
 // gitServiceHandler is the default service handler using the git binary.
+//
+// Deadline invariant: the ctx passed here must be cancellation-only — it must
+// NOT carry a context.WithDeadline or context.WithTimeout. All three transport
+// callers (SSH via gliderlabs/ssh, git daemon via pkg/daemon, HTTP via
+// net/http) enforce timeouts by calling conn.SetDeadline on the underlying
+// net.Conn, NOT by attaching a deadline to the context. If a caller were ever
+// changed to pass a deadline-carrying context, exec.CommandContext would kill
+// the git subprocess when the deadline expires, potentially corrupting an
+// in-progress push. In that case, replace ctx with a context.WithCancelCause
+// derived from context.Background() that mirrors parent cancellation but not
+// DeadlineExceeded.
 func gitServiceHandler(ctx context.Context, svc Service, scmd ServiceCommand) error {
+	// NOTE: ctx is cancellation-only (derived from context.Background via
+	// context.WithCancel). SSH and git-daemon timeouts fire as net.Conn
+	// deadline errors, not context deadlines — so no deadline can reach here
+	// and kill a long-running push or clone mid-transfer.
 	cmd := exec.CommandContext(ctx, "git")
+	// WaitDelay bounds how long we wait for stdin/stdout pipe goroutines to
+	// finish after the git process has already been killed (e.g. by context
+	// cancellation). It does NOT impose a timeout on running git operations.
+	cmd.WaitDelay = 30 * time.Second
 	cmd.Dir = scmd.Dir
 	cmd.Args = append(cmd.Args, []string{
 		// Enable partial clones
@@ -125,8 +145,11 @@ func gitServiceHandler(ctx context.Context, svc Service, scmd ServiceCommand) er
 	if scmd.Stdin != nil {
 		go func() {
 			defer stdin.Close() //nolint: errcheck
-			if _, err := io.Copy(stdin, scmd.Stdin); err != nil {
-				log.Errorf("gitServiceHandler: failed to copy stdin: %v", err)
+			if _, err := io.Copy(stdin, scmd.Stdin); err != nil && ctx.Err() == nil {
+				// Broken-pipe here is normal: git read all it needed and exited,
+				// cmd.Wait() closed the write end of the pipe before the client
+				// finished sending. Log at Debug to avoid spurious error noise.
+				log.FromContext(ctx).Debug("gitServiceHandler: stdin copy ended", "err", err)
 			}
 		}()
 	}
@@ -136,7 +159,7 @@ func gitServiceHandler(ctx context.Context, svc Service, scmd ServiceCommand) er
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if _, err := io.Copy(scmd.Stdout, stdout); err != nil {
+			if _, err := io.Copy(scmd.Stdout, stdout); err != nil && ctx.Err() == nil {
 				log.Errorf("gitServiceHandler: failed to copy stdout: %v", err)
 			}
 		}()
@@ -147,7 +170,7 @@ func gitServiceHandler(ctx context.Context, svc Service, scmd ServiceCommand) er
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if _, erro := io.Copy(scmd.Stderr, stderr); err != nil {
+			if _, erro := io.Copy(scmd.Stderr, stderr); erro != nil && ctx.Err() == nil {
 				log.Errorf("gitServiceHandler: failed to copy stderr: %v", erro)
 			}
 		}()
@@ -159,12 +182,39 @@ func gitServiceHandler(ctx context.Context, svc Service, scmd ServiceCommand) er
 	wg.Wait()
 
 	err = cmd.Wait()
-	if err != nil && errors.Is(err, os.ErrNotExist) {
-		return ErrInvalidRepo
-	} else if err != nil {
+	if err != nil {
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
-			return fmt.Errorf("%s: %s", exitErr, exitErr.Stderr)
+		// Note: errors.As correctly unwraps through errors.Join, which Go 1.20+
+		// uses when cmd.WaitDelay fires (joining the ExitError with a timeout
+		// error). Verified: errors.As(errors.Join(exitErr, timeoutErr), &exitErr)
+		// returns true. So the suppression path below is safe even when WaitDelay
+		// wraps the ExitError via errors.Join.
+		if errors.As(err, &exitErr) {
+			if errors.Is(ctx.Err(), context.Canceled) {
+				// Process exited because context was cancelled — client disconnected
+				// or server is shutting down. Expected; not worth surfacing.
+				// We do not gate on ExitCode()==-1: on Unix a signal-killed process
+				// has no exit code (-1), but on Windows TerminateProcess sets exit
+				// code 1. Checking ctx.Err() alone is portable across both.
+				log.FromContext(ctx).Debug("git process exited on context cancellation", "service", svc.Name())
+				return nil
+			}
+			// When WaitDelay fires alongside a non-zero exit, cmd.Wait returns
+			// errors.Join(exitErr, exec.ErrWaitDelay). Strip the WaitDelay noise
+			// so callers see a clean exit-status error, not an internal timeout.
+			retErr := error(exitErr)
+			if len(exitErr.Stderr) > 0 {
+				retErr = fmt.Errorf("%w: %s", exitErr, exitErr.Stderr)
+			}
+			return retErr
+		} else if errors.Is(err, exec.ErrWaitDelay) {
+			// WaitDelay (30s) expired before pipe goroutines drained. This branch
+			// is only reached when there is no accompanying ExitError (i.e. git
+			// exited 0 but the client read the pipe slowly). The git command
+			// succeeded; the drain timeout is an internal bookkeeping detail, not
+			// a caller-visible error.
+			log.FromContext(ctx).Debug("git pipe drain timed out", "service", svc.Name())
+			return nil
 		}
 
 		return err

--- a/pkg/ssh/cmd/cmd.go
+++ b/pkg/ssh/cmd/cmd.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -107,6 +108,17 @@ func CommandName(args []string) string {
 		return ""
 	}
 	return args[0]
+}
+
+// currentUser resolves the authenticated user from the session context.
+// It checks the context user first (set by AuthenticationMiddleware for
+// both public key and token auth), avoiding a redundant DB lookup.
+func currentUser(ctx context.Context) (proto.User, error) {
+	user := proto.UserFromContext(ctx)
+	if user != nil {
+		return user, nil
+	}
+	return nil, proto.ErrUserNotFound
 }
 
 func checkIfReadable(cmd *cobra.Command, args []string) error {

--- a/pkg/ssh/cmd/info.go
+++ b/pkg/ssh/cmd/info.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/charmbracelet/soft-serve/pkg/backend"
 	"github.com/charmbracelet/soft-serve/pkg/sshutils"
 	"github.com/spf13/cobra"
 )
@@ -14,9 +13,7 @@ func InfoCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			be := backend.FromContext(ctx)
-			pk := sshutils.PublicKeyFromContext(ctx)
-			user, err := be.UserByPublicKey(ctx, pk)
+			user, err := currentUser(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/ssh/cmd/list.go
+++ b/pkg/ssh/cmd/list.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/charmbracelet/soft-serve/pkg/access"
 	"github.com/charmbracelet/soft-serve/pkg/backend"
-	"github.com/charmbracelet/soft-serve/pkg/sshutils"
+	"github.com/charmbracelet/soft-serve/pkg/proto"
 	"github.com/spf13/cobra"
 )
 
@@ -19,13 +19,13 @@ func listCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			be := backend.FromContext(ctx)
-			pk := sshutils.PublicKeyFromContext(ctx)
+			user := proto.UserFromContext(ctx)
 			repos, err := be.Repositories(ctx)
 			if err != nil {
 				return err
 			}
 			for _, r := range repos {
-				if be.AccessLevelByPublicKey(ctx, r.Name(), pk) >= access.ReadOnlyAccess {
+				if be.AccessLevelForUser(ctx, r.Name(), user) >= access.ReadOnlyAccess {
 					if !r.IsHidden() || all {
 						cmd.Println(r.Name())
 					}

--- a/pkg/ssh/cmd/pubkey.go
+++ b/pkg/ssh/cmd/pubkey.go
@@ -23,8 +23,7 @@ func PubkeyCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			be := backend.FromContext(ctx)
-			pk := sshutils.PublicKeyFromContext(ctx)
-			user, err := be.UserByPublicKey(ctx, pk)
+			user, err := currentUser(ctx)
 			if err != nil {
 				return err
 			}
@@ -45,8 +44,7 @@ func PubkeyCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			be := backend.FromContext(ctx)
-			pk := sshutils.PublicKeyFromContext(ctx)
-			user, err := be.UserByPublicKey(ctx, pk)
+			user, err := currentUser(ctx)
 			if err != nil {
 				return err
 			}
@@ -67,9 +65,7 @@ func PubkeyCommand() *cobra.Command {
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
-			be := backend.FromContext(ctx)
-			pk := sshutils.PublicKeyFromContext(ctx)
-			user, err := be.UserByPublicKey(ctx, pk)
+			user, err := currentUser(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/ssh/cmd/repo.go
+++ b/pkg/ssh/cmd/repo.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/soft-serve/git"
 	"github.com/charmbracelet/soft-serve/pkg/backend"
 	"github.com/charmbracelet/soft-serve/pkg/proto"
 	"github.com/spf13/cobra"
@@ -58,7 +60,8 @@ func RepoCommand() *cobra.Command {
 				}
 
 				head, err := r.HEAD()
-				if err != nil {
+				isEmpty := errors.Is(err, git.ErrReferenceNotExist)
+				if err != nil && !isEmpty {
 					return err
 				}
 
@@ -84,7 +87,11 @@ func RepoCommand() *cobra.Command {
 				if owner != nil {
 					cmd.Println(strings.TrimSpace(fmt.Sprint("Owner: ", owner.Username())))
 				}
-				cmd.Println("Default Branch:", head.Name().Short())
+				if isEmpty {
+					cmd.Println("Default Branch: (empty repository)")
+				} else {
+					cmd.Println("Default Branch:", head.Name().Short())
+				}
 				if len(branches) > 0 {
 					cmd.Println("Branches:")
 					for _, b := range branches {

--- a/pkg/ssh/cmd/set_username.go
+++ b/pkg/ssh/cmd/set_username.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/charmbracelet/soft-serve/pkg/backend"
-	"github.com/charmbracelet/soft-serve/pkg/sshutils"
 	"github.com/spf13/cobra"
 )
 
@@ -15,8 +14,7 @@ func SetUsernameCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			be := backend.FromContext(ctx)
-			pk := sshutils.PublicKeyFromContext(ctx)
-			user, err := be.UserByPublicKey(ctx, pk)
+			user, err := currentUser(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/ssh/middleware.go
+++ b/pkg/ssh/middleware.go
@@ -55,16 +55,22 @@ func AuthenticationMiddleware(sh ssh.Handler) ssh.Handler {
 			return
 		}
 
+		// Check if this session was authenticated via access token.
+		// Token-authenticated sessions carry the user ID via a package-private
+		// context key (tokenAuthUserIDKey) set during keyboard-interactive auth.
+		// We intentionally do NOT read this from perms.Extensions — certificate
+		// extensions from gossh are merged into the same map, so a string key
+		// can be injected by a client presenting a crafted certificate.
+		_, isTokenAuth := ctx.Value(tokenAuthUserIDKey{}).(int64)
+
 		ac := be.AllowKeyless(ctx)
-		publicKeyCounter.WithLabelValues(strconv.FormatBool(ac || pk != nil)).Inc()
-		if !ac && pk == nil {
+		publicKeyCounter.WithLabelValues(strconv.FormatBool(ac || pk != nil || isTokenAuth)).Inc()
+		if !ac && pk == nil && !isTokenAuth {
 			wish.Fatalln(s, ErrPermissionDenied)
 			return
 		}
 
 		// Set the auth'd user, or anon, in the context.
-		// Token-authenticated sessions carry the user ID via a package-private
-		// context key (tokenAuthUserIDKey) set during keyboard-interactive auth.
 		var user proto.User
 		if pk != nil {
 			if u, err := be.UserByPublicKey(ctx, pk); err != nil {
@@ -75,6 +81,8 @@ func AuthenticationMiddleware(sh ssh.Handler) ssh.Handler {
 		} else if tokenID, ok := ctx.Value(tokenAuthUserIDKey{}).(int64); ok {
 			if u, err := be.UserByID(ctx, tokenID); err != nil {
 				log.FromContext(ctx).Warn("failed to resolve token-auth user", "id", tokenID, "err", err)
+				wish.Fatalln(s, ErrPermissionDenied)
+				return
 			} else {
 				user = u
 			}

--- a/pkg/ssh/session.go
+++ b/pkg/ssh/session.go
@@ -47,7 +47,7 @@ func SessionHandler(s ssh.Session) *tea.Program {
 		initialRepo = cmd[0]
 	}
 
-	auth := be.AccessLevelByPublicKey(ctx, initialRepo, s.PublicKey())
+	auth := be.AccessLevelForUser(ctx, initialRepo, proto.UserFromContext(ctx))
 	if auth < access.ReadOnlyAccess {
 		wish.Fatalln(s, proto.ErrUnauthorized)
 		return nil

--- a/pkg/ui/pages/repo/files.go
+++ b/pkg/ui/pages/repo/files.go
@@ -3,7 +3,7 @@ package repo
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -253,7 +253,7 @@ func (f *Files) Update(msg tea.Msg) (common.Model, tea.Cmd) {
 		switch sel := msg.IdentifiableItem.(type) {
 		case FileItem:
 			f.currentItem = &sel
-			f.path = filepath.Join(f.path, sel.entry.Name())
+			f.path = path.Join(f.path, sel.entry.Name())
 			if sel.entry.IsTree() {
 				cmds = append(cmds, f.selectTreeCmd)
 			} else {
@@ -458,19 +458,19 @@ func (f *Files) selectFileCmd() tea.Msg {
 		if !bin {
 			bin, err = fi.IsBinary()
 			if err != nil {
-				f.path = filepath.Dir(f.path)
+				f.path = path.Dir(f.path)
 				return common.ErrorMsg(err)
 			}
 		}
 
 		if bin {
-			f.path = filepath.Dir(f.path)
+			f.path = path.Dir(f.path)
 			return common.ErrorMsg(errBinaryFile)
 		}
 
 		c, err := fi.Bytes()
 		if err != nil {
-			f.path = filepath.Dir(f.path)
+			f.path = path.Dir(f.path)
 			return common.ErrorMsg(err)
 		}
 
@@ -527,7 +527,7 @@ func renderBlame(c common.Common, f *FileItem, b *gitm.Blame) string {
 }
 
 func (f *Files) deselectItemCmd() tea.Cmd {
-	f.path = filepath.Dir(f.path)
+	f.path = path.Dir(f.path)
 	index := 0
 	if len(f.lastSelected) > 0 {
 		index = f.lastSelected[len(f.lastSelected)-1]

--- a/pkg/ui/pages/repo/readme.go
+++ b/pkg/ui/pages/repo/readme.go
@@ -1,7 +1,7 @@
 package repo
 
 import (
-	"path/filepath"
+	"path"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
@@ -106,6 +106,7 @@ func (r *Readme) Update(msg tea.Msg) (common.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		r.SetSize(msg.Width, msg.Height)
 	case EmptyRepoMsg:
+		r.isLoading = false
 		cmds = append(cmds,
 			r.code.SetContent(defaultEmptyRepoMsg(r.common.Config(),
 				r.repo.Name()), ".md"),
@@ -147,7 +148,7 @@ func (r *Readme) SpinnerID() int {
 
 // StatusBarValue implements statusbar.StatusBar.
 func (r *Readme) StatusBarValue() string {
-	dir := filepath.Dir(r.readmePath)
+	dir := path.Dir(r.readmePath)
 	if dir == "." || dir == "" {
 		return " "
 	}
@@ -164,7 +165,10 @@ func (r *Readme) updateReadmeCmd() tea.Msg {
 	if r.repo == nil {
 		return common.ErrorMsg(common.ErrMissingRepo)
 	}
-	rm, rp, _ := backend.Readme(r.repo, r.ref)
+	rm, rp, err := backend.Readme(r.repo, r.ref)
+	if err != nil {
+		return common.ErrorMsg(err)
+	}
 	m.Content = rm
 	m.Path = rp
 	return m

--- a/pkg/ui/pages/repo/repo.go
+++ b/pkg/ui/pages/repo/repo.go
@@ -115,8 +115,11 @@ func (r *Repo) commonHelp() []key.Binding {
 	back.SetHelp("esc", "back to menu")
 	tab := r.common.KeyMap.Section
 	tab.SetHelp("tab", "switch tab")
+	copyKey := r.common.KeyMap.Copy
+	copyKey.SetHelp("c", "copy clone cmd")
 	b = append(b, back)
 	b = append(b, tab)
+	b = append(b, copyKey)
 	return b
 }
 
@@ -204,6 +207,15 @@ func (r *Repo) Update(msg tea.Msg) (common.Model, tea.Cmd) {
 			switch {
 			case key.Matches(msg, r.common.KeyMap.Back):
 				cmds = append(cmds, goBackCmd)
+			case key.Matches(msg, r.common.KeyMap.Copy):
+				// Only handle clone copy on the Readme tab to avoid
+				// conflicting with pane-level copy handlers (Files, Log, Refs, Stash).
+				if r.selectedRepo != nil && r.panes[r.activeTab].TabName() == "Readme" {
+					cmd := r.common.CloneCmd(r.common.Config().SSH.PublicURL, r.selectedRepo.Name())
+					if cmd != "" {
+						cmds = append(cmds, copyCmd(cmd, "Clone command copied to clipboard"))
+					}
+				}
 			}
 		}
 	case CopyMsg:

--- a/pkg/ui/pages/selection/item.go
+++ b/pkg/ui/pages/selection/item.go
@@ -18,6 +18,9 @@ import (
 
 var _ sort.Interface = Items{}
 
+// copiedResetMsg is sent after the copy feedback timer expires.
+type copiedResetMsg struct{ gen int }
+
 // Items is a list of Item.
 type Items []Item
 
@@ -98,9 +101,11 @@ func (i Item) Command() string {
 
 // ItemDelegate is the delegate for the item.
 type ItemDelegate struct {
-	common     *common.Common
-	activePane *pane
-	copiedIdx  int
+	common      *common.Common
+	activePane  *pane
+	copiedItem  Item
+	hasCopied   bool
+	copiedGen   int
 }
 
 // NewItemDelegate creates a new ItemDelegate.
@@ -108,7 +113,6 @@ func NewItemDelegate(common *common.Common, activePane *pane) *ItemDelegate {
 	return &ItemDelegate{
 		common:     common,
 		activePane: activePane,
-		copiedIdx:  -1,
 	}
 }
 
@@ -129,7 +133,6 @@ func (d *ItemDelegate) Spacing() int { return 1 }
 
 // Update implements list.ItemDelegate.
 func (d *ItemDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd {
-	idx := m.Index()
 	item, ok := m.SelectedItem().(Item)
 	if !ok {
 		return nil
@@ -138,11 +141,22 @@ func (d *ItemDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd {
 	case tea.KeyPressMsg:
 		switch {
 		case key.Matches(msg, d.common.KeyMap.Copy):
-			d.copiedIdx = idx
+			d.copiedItem = item
+			d.hasCopied = true
+			d.copiedGen++
+			gen := d.copiedGen
 			return tea.Batch(
 				tea.SetClipboard(item.Command()),
-				m.SetItem(idx, item),
+				func() tea.Msg {
+					time.Sleep(1500 * time.Millisecond)
+					return copiedResetMsg{gen: gen}
+				},
 			)
+		}
+	case copiedResetMsg:
+		if msg.gen == d.copiedGen {
+			d.hasCopied = false
+			d.copiedItem = Item{}
 		}
 	}
 	return nil
@@ -207,10 +221,9 @@ func (d *ItemDelegate) Render(w io.Writer, m list.Model, index int, listItem lis
 
 	cmd := i.Command()
 	cmdStyler := styles.Command.Render
-	if d.copiedIdx == index {
+	if d.hasCopied && d.copiedItem.ID() == i.ID() {
 		cmd = "(copied to clipboard)"
 		cmdStyler = styles.Desc.Render
-		d.copiedIdx = -1
 	}
 	cmd = common.TruncateString(cmd, m.Width()-styles.Base.GetHorizontalFrameSize())
 	s.WriteString(cmdStyler(cmd))

--- a/pkg/ui/pages/selection/selection.go
+++ b/pkg/ui/pages/selection/selection.go
@@ -10,6 +10,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/soft-serve/pkg/access"
 	"github.com/charmbracelet/soft-serve/pkg/backend"
+	"github.com/charmbracelet/soft-serve/pkg/proto"
 	"github.com/charmbracelet/soft-serve/pkg/ui/common"
 	"github.com/charmbracelet/soft-serve/pkg/ui/components/code"
 	"github.com/charmbracelet/soft-serve/pkg/ui/components/selector"
@@ -191,7 +192,8 @@ func (s *Selection) Init() tea.Cmd {
 	ctx := s.common.Context()
 	be := s.common.Backend()
 	pk := s.common.PublicKey()
-	if pk == nil && !be.AllowKeyless(ctx) {
+	user := proto.UserFromContext(ctx)
+	if pk == nil && user == nil && !be.AllowKeyless(ctx) {
 		return nil
 	}
 
@@ -203,7 +205,7 @@ func (s *Selection) Init() tea.Cmd {
 	for _, r := range repos {
 		if r.Name() == ".soft-serve" {
 			readme, path, err := backend.Readme(r, nil)
-			if err != nil {
+			if err != nil || path == "" {
 				continue
 			}
 
@@ -213,7 +215,7 @@ func (s *Selection) Init() tea.Cmd {
 		if r.IsHidden() {
 			continue
 		}
-		al := be.AccessLevelByPublicKey(ctx, r.Name(), pk)
+		al := be.AccessLevelForUser(ctx, r.Name(), proto.UserFromContext(ctx))
 		if al >= access.ReadOnlyAccess {
 			item, err := NewItem(s.common, r)
 			if err != nil {

--- a/testscript/script_test.go
+++ b/testscript/script_test.go
@@ -95,6 +95,7 @@ func TestScript(t *testing.T) {
 			"soft":                   cmdSoft("admin", admin1.Signer()),
 			"usoft":                  cmdSoft("user1", user1.Signer()),
 			"attacksoft":             cmdSoft("attacker", attackerSigner, attacker.Signer()),
+			"tokensoft":              cmdTokenSoft,
 			"git":                    cmdGit(admin1Key),
 			"ugit":                   cmdGit(user1Key),
 			"agit":                   cmdGit(attackerKey),
@@ -219,6 +220,48 @@ func cmdSoft(user string, keys ...ssh.Signer) func(ts *testscript.TestScript, ne
 
 		check(ts, sess.Run(strings.Join(args, " ")), neg)
 	}
+}
+
+// cmdTokenSoft connects via keyboard-interactive auth using an access token.
+// Usage: tokensoft <token> <command args...>
+func cmdTokenSoft(ts *testscript.TestScript, neg bool, args []string) {
+	if len(args) < 2 {
+		ts.Fatalf("usage: tokensoft <token> <command args...>")
+	}
+	token := args[0]
+	cmdArgs := args[1:]
+
+	cli, err := ssh.Dial(
+		"tcp",
+		net.JoinHostPort("localhost", ts.Getenv("SSH_PORT")),
+		&ssh.ClientConfig{
+			User: "git",
+			Auth: []ssh.AuthMethod{
+				ssh.KeyboardInteractive(func(name, instruction string, questions []string, echos []bool) ([]string, error) {
+					answers := make([]string, len(questions))
+					for i := range questions {
+						answers[i] = token
+					}
+					return answers, nil
+				}),
+			},
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		},
+	)
+	if neg && err != nil {
+		return
+	}
+	ts.Check(err)
+	defer cli.Close()
+
+	sess, err := cli.NewSession()
+	ts.Check(err)
+	defer sess.Close()
+
+	sess.Stdout = ts.Stdout()
+	sess.Stderr = ts.Stderr()
+
+	check(ts, sess.Run(strings.Join(cmdArgs, " ")), neg)
 }
 
 func cmdUI(key ssh.Signer) func(ts *testscript.TestScript, neg bool, args []string) {

--- a/testscript/testdata/config-initial-settings.txtar
+++ b/testscript/testdata/config-initial-settings.txtar
@@ -1,0 +1,37 @@
+# vi: set ft=conf
+
+# Test that anon_access and allow_keyless set via environment variables are
+# applied to the database on startup, overriding the migration defaults
+# (read-only-access / true).
+
+env SOFT_SERVE_ANON_ACCESS=no-access
+env SOFT_SERVE_ALLOW_KEYLESS=false
+
+exec soft serve &
+ensureserverrunning SSH_PORT
+
+# Admin can still connect
+soft info
+
+# Settings reflect what was configured, not the migration defaults
+soft settings allow-keyless
+stdout 'false'
+
+soft settings anon-access
+stdout 'no-access'
+
+# Repo created by admin is not accessible to unregistered users under no-access
+soft repo create pub1
+! ugit clone ssh://localhost:$SSH_PORT/pub1 upub1
+stderr 'not authorized|unauthorized'
+
+# Unregistered user cannot create repos either
+! usoft repo create blocked
+stderr 'unauthorized'
+
+# Change anon-access to read-only via admin and verify access is restored
+soft settings anon-access read-only
+ugit clone ssh://localhost:$SSH_PORT/pub1 upub1
+
+# stop the server
+[windows] stopserver

--- a/testscript/testdata/gitweb-owner.txtar
+++ b/testscript/testdata/gitweb-owner.txtar
@@ -1,0 +1,25 @@
+# vi: set ft=conf
+
+# Regression test for https://github.com/charmbracelet/soft-serve/issues/753
+# gitweb.owner should be set in the git config when a repo is created.
+
+# start soft serve
+exec soft serve &
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
+
+# create user1 (non-admin)
+soft user create user1 --key "$USER1_AUTHORIZED_KEY"
+
+# TEST 1: admin creates a repo — gitweb.owner should be "admin"
+soft repo create adminrepo
+readfile $DATA_PATH/repos/adminrepo.git/config
+stdout 'owner = admin'
+
+# TEST 2: user1 creates a repo — gitweb.owner should be "user1"
+usoft repo create userrepo
+readfile $DATA_PATH/repos/userrepo.git/config
+stdout 'owner = user1'
+
+# stop the server
+[windows] stopserver

--- a/testscript/testdata/readme-empty-repo.txtar
+++ b/testscript/testdata/readme-empty-repo.txtar
@@ -1,0 +1,29 @@
+# vi: set ft=conf
+
+# Regression test for https://github.com/charmbracelet/soft-serve/issues/522
+# Verifies that an empty repository can be created and queried without errors.
+# The TUI bug (infinite loading spinner on Readme tab for empty repos) is fixed
+# by setting r.isLoading = false in the EmptyRepoMsg handler in readme.go.
+
+# start soft serve
+exec soft serve &
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
+
+# create an empty repo (no initial commit, no README)
+soft repo create emptyrepo -d 'emptyrepo-issue-522'
+stderr 'Created repository emptyrepo.*'
+stdout ssh://localhost:$SSH_PORT/emptyrepo.git
+
+# verify the repo exists and reports correct metadata
+soft repo info emptyrepo
+stdout 'Repository: emptyrepo'
+stdout 'Description: emptyrepo-issue-522'
+stdout 'Default Branch: \(empty repository\)'
+
+# verify the repo directory exists on disk
+exists $DATA_PATH/repos/emptyrepo.git
+
+# stop the server
+[windows] stopserver
+[windows] ! stderr .

--- a/testscript/testdata/token-ssh-auth.txtar
+++ b/testscript/testdata/token-ssh-auth.txtar
@@ -1,0 +1,61 @@
+# vi: set ft=conf
+# Test that SSH keyboard-interactive auth validates access tokens
+# and resolves user identity for collaborator-based access control.
+#
+# Regression test for: https://github.com/charmbracelet/soft-serve/issues/800
+
+# start soft serve
+exec soft serve &
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
+
+# create a user with a public key
+soft user create user1 --key "$USER1_AUTHORIZED_KEY"
+
+# create an access token for user1
+usoft token create 'testtoken'
+stdout 'ss_.*'
+cp stdout token.txt
+envfile TOKEN=token.txt
+
+# TEST 1: Valid token authenticates successfully with AllowKeyless=false
+soft settings allow-keyless false
+tokensoft $TOKEN repo list
+
+# TEST 2: Invalid token is rejected with AllowKeyless=false
+! tokensoft invalid-token-value repo list
+
+# TEST 3: Valid token works with AllowKeyless=true
+soft settings allow-keyless true
+tokensoft $TOKEN repo list
+
+# TEST 4: Token-authenticated session has user identity (collaborator access)
+# Create a private repo only accessible to collaborators
+soft repo create private-repo -p
+soft repo collab add private-repo user1
+
+# Connect with valid token — user1 should see the private repo
+soft settings allow-keyless false
+tokensoft $TOKEN repo list
+stdout 'private-repo'
+
+# TEST 5: Invalid token with AllowKeyless=true gets anonymous access (no private repo)
+soft settings allow-keyless true
+tokensoft invalid-token-value repo list
+! stdout 'private-repo'
+
+# TEST 6: info command works with token auth
+soft settings allow-keyless false
+tokensoft $TOKEN info
+stdout 'Username: user1'
+
+# TEST 7: pubkey list works with token auth
+tokensoft $TOKEN pubkey list
+stdout 'ssh-ed25519 '
+
+# TEST 8: token list works with token auth (uses UserFromContext, already correct)
+tokensoft $TOKEN token list
+stdout 'testtoken'
+
+# stop the server
+[windows] stopserver

--- a/testscript/testdata/ui-repo-copy.txtar
+++ b/testscript/testdata/ui-repo-copy.txtar
@@ -1,0 +1,26 @@
+# vi: set ft=conf
+
+# Test for https://github.com/charmbracelet/soft-serve/issues/769
+# The 'c' shortcut to copy the clone command should be available
+# when viewing a repository in the TUI.
+
+# start soft serve
+exec soft serve &
+ensureserverrunning SSH_PORT
+
+# create a repo and push a commit so it's not empty
+soft repo create testrepo
+git clone ssh://localhost:$SSH_PORT/testrepo repo
+mkfile ./repo/README.md '# Test'
+git -C repo add -A
+git -C repo commit -m 'init'
+git -C repo push origin HEAD
+
+# open TUI, navigate into testrepo (enter), expand help (?), wait, quit
+# key sequence: wait, enter to select repo, wait, ? to expand help, wait, quit
+ui '"    \r    ?    q"'
+cp stdout repo-view.txt
+grep 'copy clone cmd' repo-view.txt
+
+# stop the server
+[windows] stopserver

--- a/testscript/testdata/user-create-key.txtar
+++ b/testscript/testdata/user-create-key.txtar
@@ -1,0 +1,42 @@
+# vi: set ft=conf
+
+# Regression test for https://github.com/charmbracelet/soft-serve/issues/750
+# user create -k "ssh-ed25519 AAAA..." should work even though the key
+# contains a space which the SSH layer splits into multiple tokens.
+
+# start soft serve
+exec soft serve &
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
+
+# TEST 1: user create with -k flag (key has a space — split across SSH args)
+soft user create alice -k "$USER1_AUTHORIZED_KEY"
+soft user info alice
+stdout 'Username: alice'
+stdout 'ssh-ed25519'
+
+# TEST 2: user alice can connect using her key
+usoft info
+stdout 'Username: alice'
+
+# TEST 3: user create with a different key works (no duplicate constraint)
+soft user create bob -k "$ADMIN2_AUTHORIZED_KEY"
+soft user info bob
+stdout 'Username: bob'
+stdout 'ssh-ed25519'
+
+# TEST 4: user create without any key still works
+soft user create charlie
+soft user info charlie
+stdout 'Username: charlie'
+
+# TEST 5: invalid key is rejected
+! soft user create dave -k 'not-a-valid-key'
+stderr 'no key found'
+
+# TEST 6: extra args without -k flag are rejected
+! soft user create eve extraarg
+stderr 'accepts 1 arg'
+
+# stop the server
+[windows] stopserver

--- a/testscript/testdata/user-create-with-key.txtar
+++ b/testscript/testdata/user-create-with-key.txtar
@@ -1,0 +1,53 @@
+# vi: set ft=conf
+
+# Regression test for https://github.com/charmbracelet/soft-serve/issues/750
+# SSH exec tokenizes commands on spaces, splitting "ssh-ed25519 AAAA..."
+# into separate args. The -k flag should reconstruct the full key.
+
+# convert crlf to lf on windows
+[windows] dos2unix user_info.txt
+
+# start soft serve
+exec soft serve &
+# wait for SSH server to start
+ensureserverrunning SSH_PORT
+
+# Create a user passing the public key via -k flag.
+# $USER1_AUTHORIZED_KEY expands to "ssh-ed25519 AAAA..." (two space-separated
+# tokens). When sent over SSH exec and re-split by the server, the key type
+# and key data become separate positional args — this is the bug from #750.
+soft user create testuser -k $USER1_AUTHORIZED_KEY
+
+# Verify the user exists and has the key attached.
+soft user info testuser
+cmpenv stdout user_info.txt
+
+# Create a second user passing the public key as positional args (no -k flag).
+# This exercises the SSH-exec tokenization reconstruction path: the client
+# sends "user create testuser2 ssh-ed25519 AAAA..." and the server receives
+# "testuser2", "ssh-ed25519", "AAAA..." as separate positional args.
+soft user create testuser2 $USER1_AUTHORIZED_KEY
+
+# Verify the second user also has the key attached correctly.
+soft user info testuser2
+cmpenv stdout user2_info.txt
+
+# Reject empty -k flag value.
+! soft user create baduser -k ''
+stderr 'non-empty'
+
+# stop the server
+[windows] stopserver
+[windows] ! stderr .
+
+-- user_info.txt --
+Username: testuser
+Admin: false
+Public keys:
+  $USER1_AUTHORIZED_KEY
+
+-- user2_info.txt --
+Username: testuser2
+Admin: false
+Public keys:
+  $USER1_AUTHORIZED_KEY


### PR DESCRIPTION
## Summary

Merge all accumulated fixes and features from `dev` into `main`.

## Conflict resolution

- **server.go**: kept main's complete version (shutdownOnce, monitor goroutine, listener cleanup on partial bind failure, TLS validation guard)
- **ssh.go**: kept main's `tokenAuthUserIDKey{}` secure context key approach
- **middleware.go**: combined both — main's secure `tokenAuthUserIDKey{}` for user resolution + dev's correct gate check (`!isTokenAuth`) so token-auth sessions work when `AllowKeyless=false`
- **cmd/user.go**: kept main's cleaner key reconstruction
- **web/git.go**: kept main's version (raw blob endpoint, correct EOF-with-data + ErrShortWrite fix)
- **web/http.go**: kept main's TLS validation guard

## Key changes from dev

- fix(git): prevent zombie processes on context-cancelled git commands
- fix(ssh): create host key directory before generating key
- fix(ssh): user create -k correctly handles space-separated public keys
- fix(ui): multiple TUI copy/clipboard/spinner/README fixes
- fix(backend): README search improvements, error propagation
- feat(config): add anon_access and allow_keyless config fields
- Various Windows compatibility fixes

## Test plan

- [ ] `go vet ./...` passes ✓
- [ ] `go test ./...` passes
- [ ] Smoke test: start server, clone repo, push repo