### PR TITLE
fix(jobs): set no timeout on mirror sync git commands

### DIFF
--- a/pkg/jobs/mirror.go
+++ b/pkg/jobs/mirror.go
@@ -85,6 +85,7 @@ func (m mirrorPull) Func(ctx context.Context) func() {
 
 						if _, err := cmd.RunInDir(r.Path); err != nil {
 							logger.Error("error running git remote update", "repo", name, "err", err)
+							break
 						}
 					}
 


### PR DESCRIPTION
Mirror sync jobs were being killed by the 1-minute default timeout on large repos.