### PR TITLE
fix(lfs): fix open file handle blocking rename and concurrent upload race

### DIFF
--- a/pkg/git/lfs.go
+++ b/pkg/git/lfs.go
@@ -147,12 +147,6 @@ func (t *lfsTransfer) Upload(oid string, size int64, r io.Reader, _ transfer.Arg
 		return err
 	}
 
-	obj, err := t.storage.Open(tempName)
-	if err != nil {
-		t.logger.Errorf("error opening object: %v", err)
-		return err
-	}
-
 	pointer := transfer.Pointer{
 		Oid: oid,
 	}
@@ -167,7 +161,7 @@ func (t *lfsTransfer) Upload(oid string, size int64, r io.Reader, _ transfer.Arg
 	}
 
 	expectedPath := path.Join("objects", pointer.RelativePath())
-	if err := t.storage.Rename(obj.Name(), expectedPath); err != nil {
+	if err := t.storage.Rename(tempName, expectedPath); err != nil {
 		t.logger.Errorf("error renaming object: %v", err)
 		_ = t.store.DeleteLFSObjectByOid(t.ctx, t.dbx, t.repo.ID(), pointer.Oid)
 		return err

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -356,6 +356,12 @@ func serviceLfsBasicUpload(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := datastore.CreateLFSObject(ctx, dbx, repo.ID(), oid, size); err != nil {
+		if errors.Is(err, db.ErrDuplicateKey) {
+			// A concurrent upload for the same OID already committed the record;
+			// treat as idempotent success (git-lfs sends parallel PUTs for large pushes).
+			renderStatus(http.StatusOK)(w, nil)
+			return
+		}
 		logger.Error("error creating object", "oid", oid, "err", err)
 		renderJSON(w, http.StatusInternalServerError, lfs.ErrorResponse{
 			Message: "internal server error",


### PR DESCRIPTION
Fixes two LFS upload bugs: open file handle blocking rename on Windows, and concurrent upload duplicate-key race on HTTP.