### PR TITLE
fix(server): pre-bind listeners, idempotent Shutdown, TLS guard

### DIFF
--- a/cmd/soft/serve/server.go
+++ b/cmd/soft/serve/server.go
@@ -5,7 +5,10 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"sync"
+	"time"
 
 	"charm.land/log/v2"
 
@@ -34,8 +37,10 @@ type Server struct {
 	Backend     *backend.Backend
 	DB          *db.DB
 
-	logger *log.Logger
-	ctx    context.Context
+	logger       *log.Logger
+	ctx          context.Context
+	shutdownOnce sync.Once
+	shutdownErr  error
 }
 
 // NewServer returns a new *Server configured to serve Soft Serve. The SSH
@@ -111,48 +116,131 @@ func (s *Server) ReloadCertificates() error {
 	return s.CertLoader.Reload()
 }
 
-// Start starts the SSH server.
+// Start starts all configured servers.
 func (s *Server) Start() error {
-	errg, _ := errgroup.WithContext(s.ctx)
+	// Pre-bind all configured listeners synchronously. If any bind fails
+	// (e.g. EACCES on a privileged port or address already in use) we
+	// return an error immediately with a clear message, rather than
+	// silently continuing while other servers run without the failing one.
+	var (
+		sshLn   net.Listener
+		gitLn   net.Listener
+		httpLn  net.Listener
+		statsLn net.Listener
+		err     error
+	)
 
-	// optionally start the SSH server
+	// closeAll holds listeners opened so far; cleared once all binds
+	// succeed so that the defer does not double-close them.
+	var closeAll []net.Listener
+	defer func() {
+		for _, ln := range closeAll {
+			ln.Close() //nolint:errcheck
+		}
+	}()
+
+	if s.Config.SSH.Enabled {
+		sshLn, err = net.Listen("tcp", s.Config.SSH.ListenAddr)
+		if err != nil {
+			return fmt.Errorf("ssh listen %s: %w", s.Config.SSH.ListenAddr, err)
+		}
+		closeAll = append(closeAll, sshLn)
+	}
+
+	if s.Config.Git.Enabled {
+		gitLn, err = net.Listen("tcp", s.Config.Git.ListenAddr)
+		if err != nil {
+			return fmt.Errorf("git daemon listen %s: %w", s.Config.Git.ListenAddr, err)
+		}
+		closeAll = append(closeAll, gitLn)
+	}
+
+	if s.Config.HTTP.Enabled {
+		httpLn, err = net.Listen("tcp", s.Config.HTTP.ListenAddr)
+		if err != nil {
+			return fmt.Errorf("http listen %s: %w", s.Config.HTTP.ListenAddr, err)
+		}
+		closeAll = append(closeAll, httpLn)
+	}
+
+	if s.Config.Stats.Enabled {
+		statsLn, err = net.Listen("tcp", s.Config.Stats.ListenAddr)
+		if err != nil {
+			return fmt.Errorf("stats listen %s: %w", s.Config.Stats.ListenAddr, err)
+		}
+		closeAll = append(closeAll, statsLn)
+	}
+
+	// All binds succeeded; goroutines take ownership of each listener.
+	closeAll = nil
+
+	errg, gctx := errgroup.WithContext(s.ctx)
+
+	// External monitor goroutine: if any server goroutine returns an
+	// error, shut down all remaining servers so errg.Wait() unblocks
+	// and the caller sees the error. Runs *outside* the errgroup so it
+	// never blocks errg.Wait() itself.
+	// gctx is always cancelled — either by an erroring goroutine or by
+	// errg.Wait() itself on return — so this goroutine never leaks.
+	go func() {
+		<-gctx.Done()
+		// errgroup (golang.org/x/sync >= v0.12.0) uses
+		// context.WithCancelCause internally and calls cancel(g.err)
+		// on Wait(). If every goroutine returns nil, g.err == nil and
+		// context.Cause(gctx) == nil — skip to avoid a redundant call.
+		// If a goroutine returned a non-nil error, Cause != nil and we
+		// must shut down the remaining servers ourselves.
+		//
+		// Invariant: all ErrServerClosed variants MUST be filtered in
+		// the errg.Go wrappers above; any that leak would incorrectly
+		// trigger this path.
+		//
+		// s.Shutdown is idempotent (shutdownOnce-protected), so it is
+		// safe if serve.go's SIGTERM handler races to call it first.
+		if context.Cause(gctx) == nil {
+			return
+		}
+		shutCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if shutErr := s.Shutdown(shutCtx); shutErr != nil {
+			s.logger.Error("error shutting down after unexpected server failure", "err", shutErr)
+		}
+	}()
+
 	if s.Config.SSH.Enabled {
 		errg.Go(func() error {
 			s.logger.Print("Starting SSH server", "addr", s.Config.SSH.ListenAddr)
-			if err := s.SSHServer.ListenAndServe(); !errors.Is(err, ssh.ErrServerClosed) {
+			if err := s.SSHServer.Serve(sshLn); !errors.Is(err, ssh.ErrServerClosed) {
 				return err
 			}
 			return nil
 		})
 	}
 
-	// optionally start the git daemon
 	if s.Config.Git.Enabled {
 		errg.Go(func() error {
 			s.logger.Print("Starting Git daemon", "addr", s.Config.Git.ListenAddr)
-			if err := s.GitDaemon.ListenAndServe(); !errors.Is(err, daemon.ErrServerClosed) {
+			if err := s.GitDaemon.Serve(gitLn); !errors.Is(err, daemon.ErrServerClosed) {
 				return err
 			}
 			return nil
 		})
 	}
 
-	// optionally start the HTTP server
 	if s.Config.HTTP.Enabled {
 		errg.Go(func() error {
 			s.logger.Print("Starting HTTP server", "addr", s.Config.HTTP.ListenAddr)
-			if err := s.HTTPServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			if err := s.HTTPServer.Serve(httpLn); !errors.Is(err, http.ErrServerClosed) {
 				return err
 			}
 			return nil
 		})
 	}
 
-	// optionally start the Stats server
 	if s.Config.Stats.Enabled {
 		errg.Go(func() error {
 			s.logger.Print("Starting Stats server", "addr", s.Config.Stats.ListenAddr)
-			if err := s.StatsServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			if err := s.StatsServer.Serve(statsLn); !errors.Is(err, http.ErrServerClosed) {
 				return err
 			}
 			return nil
@@ -166,8 +254,19 @@ func (s *Server) Start() error {
 	return errg.Wait()
 }
 
-// Shutdown lets the server gracefully shutdown.
+// Shutdown lets the server gracefully shutdown. It is safe to call
+// concurrently; only the first call performs the actual shutdown.
+// Subsequent callers block until the first completes and then receive
+// the same error, so the process exit code reflects the real outcome
+// regardless of which path (monitor goroutine or SIGTERM handler) wins.
 func (s *Server) Shutdown(ctx context.Context) error {
+	s.shutdownOnce.Do(func() {
+		s.shutdownErr = s.shutdown(ctx)
+	})
+	return s.shutdownErr
+}
+
+func (s *Server) shutdown(ctx context.Context) error {
 	errg, ctx := errgroup.WithContext(ctx)
 	errg.Go(func() error {
 		return s.GitDaemon.Shutdown(ctx)

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -2,6 +2,7 @@ package stats
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"time"
 
@@ -33,6 +34,13 @@ func NewStatsServer(ctx context.Context) (*StatsServer, error) {
 			MaxHeaderBytes:    http.DefaultMaxHeaderBytes,
 		},
 	}, nil
+}
+
+// Serve accepts connections on l and serves HTTP requests.
+// The stats endpoint intentionally does not support TLS; it is expected
+// to be exposed only on a loopback or internal network interface.
+func (s *StatsServer) Serve(l net.Listener) error {
+	return s.server.Serve(l)
 }
 
 // ListenAndServe starts the StatsServer.

--- a/pkg/web/http.go
+++ b/pkg/web/http.go
@@ -3,6 +3,8 @@ package web
 import (
 	"context"
 	"crypto/tls"
+	"errors"
+	"net"
 	"net/http"
 	"time"
 
@@ -48,9 +50,33 @@ func (s *HTTPServer) Close() error {
 	return s.Server.Close()
 }
 
+// Serve accepts connections on l and serves HTTP requests.
+func (s *HTTPServer) Serve(l net.Listener) error {
+	if s.Server.TLSConfig != nil {
+		// ServeTLS with empty cert/key paths is only valid when at least
+		// one certificate source is set on the TLSConfig: Certificates,
+		// GetCertificate, or GetConfigForClient (which can supply a full
+		// tls.Config dynamically, e.g. for SNI-based routing).
+		tlsCfg := s.Server.TLSConfig
+		if len(tlsCfg.Certificates) == 0 &&
+			tlsCfg.GetCertificate == nil &&
+			tlsCfg.GetConfigForClient == nil {
+			return errors.New("TLS configured but no certificate source provided (set Certificates, GetCertificate, or GetConfigForClient)")
+		}
+		return s.Server.ServeTLS(l, "", "")
+	}
+	return s.Server.Serve(l)
+}
+
 // ListenAndServe starts the HTTP server.
 func (s *HTTPServer) ListenAndServe() error {
 	if s.Server.TLSConfig != nil {
+		tlsCfg := s.Server.TLSConfig
+		if len(tlsCfg.Certificates) == 0 &&
+			tlsCfg.GetCertificate == nil &&
+			tlsCfg.GetConfigForClient == nil {
+			return errors.New("TLS configured but no certificate source provided (set Certificates, GetCertificate, or GetConfigForClient)")
+		}
 		return s.Server.ListenAndServeTLS("", "")
 	}
 	return s.Server.ListenAndServe()


### PR DESCRIPTION
Server now binds all listeners synchronously before starting goroutines. Bind errors surface immediately.