### PR TITLE
fix(ui): use path.Join/Dir instead of filepath for git tree paths

### DIFF
--- a/git/utils.go
+++ b/git/utils.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/gobwas/glob"
@@ -10,7 +11,7 @@ import (
 // LatestFile returns the contents of the first file at the specified path pattern in the repository and its file path.
 func LatestFile(repo *Repository, ref *Reference, pattern string) (string, string, error) {
 	g := glob.MustCompile(pattern)
-	dir := filepath.Dir(pattern)
+	dir := path.Dir(pattern)
 	if ref == nil {
 		head, err := repo.HEAD()
 		if err != nil {
@@ -28,7 +29,7 @@ func LatestFile(repo *Repository, ref *Reference, pattern string) (string, strin
 	}
 	for _, e := range ents {
 		te := e
-		fp := filepath.Join(dir, te.Name())
+		fp := path.Join(dir, te.Name())
 		if te.IsTree() {
 			continue
 		}

--- a/pkg/ui/pages/repo/files.go
+++ b/pkg/ui/pages/repo/files.go
@@ -3,7 +3,7 @@ package repo
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -253,7 +253,7 @@ func (f *Files) Update(msg tea.Msg) (common.Model, tea.Cmd) {
 		switch sel := msg.IdentifiableItem.(type) {
 		case FileItem:
 			f.currentItem = &sel
-			f.path = filepath.Join(f.path, sel.entry.Name())
+			f.path = path.Join(f.path, sel.entry.Name())
 			if sel.entry.IsTree() {
 				cmds = append(cmds, f.selectTreeCmd)
 			} else {
@@ -458,19 +458,19 @@ func (f *Files) selectFileCmd() tea.Msg {
 		if !bin {
 			bin, err = fi.IsBinary()
 			if err != nil {
-				f.path = filepath.Dir(f.path)
+				f.path = path.Dir(f.path)
 				return common.ErrorMsg(err)
 			}
 		}
 
 		if bin {
-			f.path = filepath.Dir(f.path)
+			f.path = path.Dir(f.path)
 			return common.ErrorMsg(errBinaryFile)
 		}
 
 		c, err := fi.Bytes()
 		if err != nil {
-			f.path = filepath.Dir(f.path)
+			f.path = path.Dir(f.path)
 			return common.ErrorMsg(err)
 		}
 
@@ -527,7 +527,7 @@ func renderBlame(c common.Common, f *FileItem, b *gitm.Blame) string {
 }
 
 func (f *Files) deselectItemCmd() tea.Cmd {
-	f.path = filepath.Dir(f.path)
+	f.path = path.Dir(f.path)
 	index := 0
 	if len(f.lastSelected) > 0 {
 		index = f.lastSelected[len(f.lastSelected)-1]

--- a/pkg/ui/pages/repo/readme.go
+++ b/pkg/ui/pages/repo/readme.go
@@ -1,7 +1,7 @@
 package repo
 
 import (
-	"path/filepath"
+	"path"
 
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/spinner"
@@ -106,6 +106,7 @@ func (r *Readme) Update(msg tea.Msg) (common.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		r.SetSize(msg.Width, msg.Height)
 	case EmptyRepoMsg:
+		r.isLoading = false
 		cmds = append(cmds,
 			r.code.SetContent(defaultEmptyRepoMsg(r.common.Config(),
 				r.repo.Name()), ".md"),
@@ -147,7 +148,7 @@ func (r *Readme) SpinnerID() int {
 
 // StatusBarValue implements statusbar.StatusBar.
 func (r *Readme) StatusBarValue() string {
-	dir := filepath.Dir(r.readmePath)
+	dir := path.Dir(r.readmePath)
 	if dir == "." || dir == "" {
 		return " "
 	}
@@ -164,7 +165,10 @@ func (r *Readme) updateReadmeCmd() tea.Msg {
 	if r.repo == nil {
 		return common.ErrorMsg(common.ErrMissingRepo)
 	}
-	rm, rp, _ := backend.Readme(r.repo, r.ref)
+	rm, rp, err := backend.Readme(r.repo, r.ref)
+	if err != nil {
+		return common.ErrorMsg(err)
+	}
 	m.Content = rm
 	m.Path = rp
 	return m


### PR DESCRIPTION
Git tree paths use forward slashes on all platforms. filepath.Join/Dir was producing backslashes on Windows.