### PR TITLE
fix(lfs): enable SQLite WAL mode and idempotent rename for concurrent uploads

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"charm.land/log/v2"
 	"github.com/charmbracelet/soft-serve/pkg/config"
@@ -24,6 +25,12 @@ func Open(ctx context.Context, driverName string, dsn string) (*DB, error) {
 	db, err := sqlx.ConnectContext(ctx, driverName, dsn)
 	if err != nil {
 		return nil, err
+	}
+
+	if strings.HasPrefix(driverName, "sqlite") {
+		if _, err := db.ExecContext(ctx, "PRAGMA journal_mode=WAL"); err != nil {
+			return nil, fmt.Errorf("enable WAL mode: %w", err)
+		}
 	}
 
 	d := &DB{

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -76,6 +76,13 @@ func (l *LocalStorage) Rename(oldName, newName string) error {
 		return err
 	}
 
+	// If destination already exists the object was uploaded concurrently.
+	// Remove the temp file and return success — the stored copy is authoritative.
+	if _, err := os.Stat(newName); err == nil {
+		_ = os.Remove(oldName)
+		return nil
+	}
+
 	return os.Rename(oldName, newName)
 }
 


### PR DESCRIPTION
## Summary

Two fixes for concurrent LFS upload failures reported in #770:

1. **SQLite WAL mode** — enable `PRAGMA journal_mode=WAL` on every SQLite
   connection open. WAL allows one writer + many concurrent readers,
   eliminating `SQLITE_BUSY (5)` errors that occurred when multiple HTTP
   LFS upload handlers raced to insert LFS object records simultaneously.

2. **Idempotent `Rename`** — when two goroutines upload the same LFS
   object at the same time, both eventually call `Rename` to the same
   destination. On Windows, `os.Rename` fails with "file in use" when
   the destination already exists. Detect this by stat-ing the destination
   first; if it already exists, remove the temp file and return `nil` — the
   stored copy is authoritative.

Closes #770