### PR TITLE
fix(ssh): record only first offered public-key fingerprint

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -187,9 +187,15 @@ func (s *SSHServer) PublicKeyHandler(ctx ssh.Context, pk ssh.PublicKey) (allowed
 	initializePermissions(ctx)
 	perms := ctx.Permissions()
 
-	// Set the public key fingerprint to be used for authentication.
-	perms.Extensions["pubkey-fp"] = gossh.FingerprintSHA256(pk)
-	ctx.SetValue(ssh.ContextKeyPermissions, perms)
+	// Only record the first offered key — the SSH client will use this
+	// key for the authenticated signature step. Overwriting on each probe
+	// would store the LAST key offered, which may differ from the one the
+	// client ultimately signs with, causing a fingerprint mismatch in
+	// AuthenticationMiddleware.
+	if perms.Extensions["pubkey-fp"] == "" {
+		perms.Extensions["pubkey-fp"] = gossh.FingerprintSHA256(pk)
+		ctx.SetValue(ssh.ContextKeyPermissions, perms)
+	}
 
 	return
 }


### PR DESCRIPTION
## Summary

When an SSH client has multiple keys in its agent, `PublicKeyHandler` is
called once per key during the *probe* phase. Each call was overwriting
`pubkey-fp` with the latest key's fingerprint. `AuthenticationMiddleware`
then compared the actual authenticated key against this last-stored
fingerprint — a mismatch when the client authenticates with the *first*
accepted key but the last probe wrote a different key's fingerprint.

Result: users connecting from remote hosts with ssh-agent get
`ErrPermissionDenied` or `ErrUserNotFound` despite having a valid
registered key.

## Fix

Only record `pubkey-fp` on the first call to `PublicKeyHandler`. The SSH
client will use the first key the server accepts; subsequent probes are
ignored.

Closes #740