### PR TITLE
feat(ssh): add allow_mouse_events config to restore terminal text selection

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,12 @@ type SSHConfig struct {
 
 	// IdleTimeout is the number of seconds a connection can be idle before it is closed.
 	IdleTimeout int `env:"IDLE_TIMEOUT" yaml:"idle_timeout"`
+
+	// AllowMouseEvents controls whether the TUI enables mouse-event capture.
+	// When true (the default), mouse clicks and scrolling work in the TUI but
+	// the terminal's native text-selection is disabled.  Set to false to
+	// restore terminal text selection at the cost of mouse-driven navigation.
+	AllowMouseEvents bool `env:"ALLOW_MOUSE_EVENTS" yaml:"allow_mouse_events"`
 }
 
 // GitConfig is the Git daemon configuration for the server.
@@ -362,10 +368,11 @@ func DefaultConfig() *Config {
 		Name:     "Soft Serve",
 		DataPath: DefaultDataPath(),
 		SSH: SSHConfig{
-			Enabled:       true,
-			ListenAddr:    ":23231",
-			PublicURL:     "ssh://localhost:23231",
-			KeyPath:       filepath.Join("ssh", "soft_serve_host_ed25519"),
+			Enabled:          true,
+			ListenAddr:       ":23231",
+			PublicURL:        "ssh://localhost:23231",
+			KeyPath:          filepath.Join("ssh", "soft_serve_host_ed25519"),
+			AllowMouseEvents: true,
 			ClientKeyPath: filepath.Join("ssh", "soft_serve_client_ed25519"),
 			MaxTimeout:    0,
 			IdleTimeout:   10 * 60, // 10 minutes

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -48,6 +48,11 @@ ssh:
   # A value of 0 means no timeout.
   idle_timeout: {{ .SSH.IdleTimeout }}
 
+  # Allow mouse events in the TUI. When true (default), mouse clicks and
+  # scrolling work in the TUI. Set to false to restore terminal text selection.
+  # Can also be controlled with SOFT_SERVE_SSH_ALLOW_MOUSE_EVENTS=false.
+  allow_mouse_events: {{ .SSH.AllowMouseEvents }}
+
 # The Git daemon configuration.
 git:
   # Enable the Git daemon.

--- a/pkg/ssh/ui.go
+++ b/pkg/ssh/ui.go
@@ -259,7 +259,12 @@ func (ui *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (ui *UI) View() tea.View {
 	var v tea.View
 	v.AltScreen = true
-	v.MouseMode = tea.MouseModeCellMotion
+	// Respect the allow_mouse_events config: when false, disable TUI mouse
+	// capture so the terminal's native text-selection works instead.
+	cfg := ui.common.Config()
+	if cfg == nil || cfg.SSH.AllowMouseEvents {
+		v.MouseMode = tea.MouseModeCellMotion
+	}
 
 	var view string
 	wm, hm := ui.getMargins()


### PR DESCRIPTION
## Summary

The TUI unconditionally set `MouseModeCellMotion`, capturing all mouse events for click-based navigation. This prevented users from selecting and copying text in their terminal emulator while soft-serve was running.

## Fix

Add `SSHConfig.AllowMouseEvents` (default `true`) that controls whether the TUI captures mouse events:

- `allow_mouse_events: true` (default) — mouse clicks and scroll work in the TUI
- `allow_mouse_events: false` — terminal native text-selection is restored; mouse navigation is disabled

Also settable via env var: `SOFT_SERVE_SSH_ALLOW_MOUSE_EVENTS=false`.

Closes #462