### PR TITLE
harden(security): comprehensive security hardening pass

### DIFF
--- a/pkg/backend/auth.go
+++ b/pkg/backend/auth.go
@@ -13,7 +13,7 @@ const saltySalt = "salty-soft-serve"
 
 // HashPassword hashes the password using bcrypt.
 func HashPassword(password string) (string, error) {
-	crypt, err := bcrypt.GenerateFromPassword([]byte(password+saltySalt), bcrypt.DefaultCost)
+	crypt, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return "", err
 	}
@@ -23,7 +23,7 @@ func HashPassword(password string) (string, error) {
 
 // VerifyPassword verifies the password against the hash.
 func VerifyPassword(password, hash string) bool {
-	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password+saltySalt))
+	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
 	return err == nil
 }
 

--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -2,7 +2,9 @@ package backend
 
 import (
 	"context"
+	"net/url"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/soft-serve/pkg/db"
@@ -50,6 +52,13 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 	for _, m := range mirrors {
 		if !m.Enabled {
 			continue
+		}
+		if u, err := url.Parse(m.RemoteURL); err == nil {
+			scheme := strings.ToLower(u.Scheme)
+			if scheme == "file" {
+				b.logger.Warn("push mirror: blocked file:// URL", "url", m.RemoteURL)
+				continue // skip this mirror
+			}
 		}
 		sem <- struct{}{} // acquire
 		go func(m models.PushMirror) {

--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -160,7 +160,7 @@ func (d *Backend) ImportRepository(_ context.Context, name string, user proto.Us
 				Timeout: -1,
 				Context: ctx,
 				Envs: []string{
-					fmt.Sprintf(`GIT_SSH_COMMAND=ssh -o UserKnownHostsFile="%s" -o StrictHostKeyChecking=no -i "%s"`,
+					fmt.Sprintf(`GIT_SSH_COMMAND=ssh -o UserKnownHostsFile="%s" -o StrictHostKeyChecking=accept-new -i "%s"`,
 						filepath.Join(d.cfg.DataPath, "ssh", "known_hosts"),
 						d.cfg.SSH.ClientKeyPath,
 					),

--- a/pkg/backend/user.go
+++ b/pkg/backend/user.go
@@ -208,7 +208,7 @@ func (d *Backend) UserByAccessToken(ctx context.Context, token string) (proto.Us
 		if errors.Is(err, db.ErrRecordNotFound) {
 			return nil, proto.ErrUserNotFound
 		}
-		d.logger.Error("failed to find user by access token", "err", err, "token", token)
+		d.logger.Error("failed to find user by access token", "err", err)
 		return nil, err
 	}
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -51,7 +51,7 @@ func EnsureWithin(reposDir string, repo string) error {
 	}
 
 	// ensure the repo is within the repos directory
-	if !strings.HasPrefix(absRepo, absRepos) {
+	if !strings.HasPrefix(absRepo, absRepos+string(filepath.Separator)) && absRepo != absRepos {
 		log.Debugf("repo path is outside of repos directory: %s", absRepo)
 		return ErrInvalidRepo
 	}

--- a/pkg/git/lfs_auth.go
+++ b/pkg/git/lfs_auth.go
@@ -72,7 +72,7 @@ func LFSAuthenticate(ctx context.Context, cmd ServiceCommand) error {
 	}
 
 	href := fmt.Sprintf("%s/%s.git/info/lfs", cfg.HTTP.PublicURL, repo.Name())
-	logger.Debug("generated token", "token", j, "href", href, "expires_at", expiresAt)
+	logger.Debug("generated token", "href", href, "expires_at", expiresAt)
 
 	return json.NewEncoder(cmd.Stdout).Encode(lfs.AuthenticateResponse{
 		Header: map[string]string{

--- a/pkg/jobs/mirror.go
+++ b/pkg/jobs/mirror.go
@@ -75,7 +75,7 @@ func (m mirrorPull) Func(ctx context.Context) func() {
 					}
 
 					// Build the SSH env once; reused for every git command below.
-					sshEnv := fmt.Sprintf(`GIT_SSH_COMMAND=ssh -o UserKnownHostsFile="%s" -o StrictHostKeyChecking=no -i "%s"`,
+					sshEnv := fmt.Sprintf(`GIT_SSH_COMMAND=ssh -o UserKnownHostsFile="%s" -o StrictHostKeyChecking=accept-new -i "%s"`,
 						filepath.Join(cfg.DataPath, "ssh", "known_hosts"),
 						cfg.SSH.ClientKeyPath,
 					)

--- a/pkg/ssh/cmd/push_mirror.go
+++ b/pkg/ssh/cmd/push_mirror.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -83,7 +84,16 @@ func validateMirrorURL(rawURL string) error {
 	case "https", "http", "ssh":
 		return nil
 	case "":
-		// SCP-style SSH remote like git@github.com:org/repo.git — allowed
+		// SCP-style SSH remotes (git@host:path) are allowed.
+		// Bare local paths like /etc/shadow or ./relative are not.
+		if strings.HasPrefix(u.Path, "/") || strings.HasPrefix(u.Path, ".") {
+			return errors.New("local file paths are not allowed as mirror remotes")
+		}
+		// For SCP-style, url.Parse puts the whole thing in Opaque or Path.
+		// Ensure there's a recognizable host:path separator (colon).
+		if !strings.Contains(rawURL, ":") {
+			return errors.New("invalid mirror remote URL: no host specified")
+		}
 		return nil
 	default:
 		return fmt.Errorf("mirror URL scheme %q is not allowed (use https, http, or ssh)", u.Scheme)

--- a/pkg/ssh/middleware.go
+++ b/pkg/ssh/middleware.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"charm.land/log/v2"
@@ -215,9 +216,15 @@ func LoggingMiddleware(sh ssh.Handler) ssh.Handler {
 		}
 
 		if config.IsVerbose() {
+			safeEnvs := make([]string, 0, len(s.Environ()))
+			for _, e := range s.Environ() {
+				if strings.HasPrefix(e, "GIT_") || strings.HasPrefix(e, "GIT_PROTOCOL") || e == "TERM" || e == "LANG" || strings.HasPrefix(e, "LC_") {
+					safeEnvs = append(safeEnvs, e)
+				}
+			}
 			logArgs = append(logArgs,
 				"key", hpk,
-				"envs", s.Environ(),
+				"envs", safeEnvs,
 			)
 		}
 

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -78,7 +78,7 @@ func parseAuthHdr(r *http.Request) (proto.User, error) {
 	logger := log.FromContext(ctx).WithPrefix("http.auth")
 	be := backend.FromContext(ctx)
 
-	logger.Debug("authorization auth header", "header", header)
+	logger.Debug("authorization auth header", "scheme", strings.SplitN(header, " ", 2)[0])
 
 	parts := strings.SplitN(header, " ", 2)
 	if len(parts) != 2 {

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -337,6 +337,9 @@ func serviceLfsBasicUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	const maxLFSObjectSize = 5 << 30 // 5 GiB
+	r.Body = http.MaxBytesReader(w, r.Body, maxLFSObjectSize)
+
 	pointer := lfs.Pointer{Oid: oid}
 	if _, err := strg.Put(path.Join("objects", pointer.RelativePath()), r.Body); err != nil {
 		logger.Error("error writing object", "oid", oid, "err", err)

--- a/pkg/web/http.go
+++ b/pkg/web/http.go
@@ -31,6 +31,7 @@ func NewHTTPServer(ctx context.Context) (*HTTPServer, error) {
 			Addr:              cfg.HTTP.ListenAddr,
 			Handler:           NewRouter(ctx),
 			ReadHeaderTimeout: time.Second * 10,
+			WriteTimeout:      5 * time.Minute,
 			IdleTimeout:       time.Second * 10,
 			MaxHeaderBytes:    http.DefaultMaxHeaderBytes,
 			ErrorLog:          logger.StandardLog(log.StandardLogOptions{ForceLevel: log.ErrorLevel}),

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -116,7 +116,7 @@ func SendWebhook(ctx context.Context, w models.Webhook, event Event, payload int
 
 		if res.Body != nil {
 			defer res.Body.Close() //nolint: errcheck
-			b, err := io.ReadAll(res.Body)
+			b, err := io.ReadAll(io.LimitReader(res.Body, 1<<20)) // 1 MiB
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

Applies 12 targeted security fixes identified in a STRIDE + OWASP Top 10 audit of the entire application.

## Changes

### MUST-FIX (credential exposure & SSRF)
- **F1** `pkg/git/lfs_auth.go` — Remove JWT bearer token from debug log (was fully logged, now logs only href + expires_at)
- **F2** `pkg/web/auth.go` — Log only auth scheme, not full `Authorization: Token <secret>` header value  
- **F3** `pkg/backend/user.go` — Remove SHA-256-hashed token from access-token error log
- **F4** `pkg/backend/auth.go` — Remove static `saltySalt` from bcrypt (bcrypt generates its own per-hash salt; the static pepper provided no security benefit and implied false confidence)
- **F5** `pkg/backend/push_mirror.go` — Block `file://` scheme in `PushMirrors()` execution path (prevents `git push --mirror file:///etc/shadow`)
- **F6** `pkg/ssh/cmd/push_mirror.go` — Reject bare local paths (`/etc/shadow`, `./relative`) in SCP-style URL validation

### SHOULD-FIX (MitM & DoS)
- **F7** `pkg/backend/repo.go` — `StrictHostKeyChecking=no` → `accept-new` (rejects changed host keys, prevents MitM on existing mirrors)
- **F8** `pkg/jobs/mirror.go` — Same `StrictHostKeyChecking` fix for pull mirror cron job
- **F9** `pkg/web/git_lfs.go` — `http.MaxBytesReader(5 GiB)` before LFS object body write (prevents disk exhaustion by write-access users)
- **F10** `pkg/webhook/webhook.go` — `io.LimitReader(1 MiB)` on webhook response body (prevents memory exhaustion from adversarial webhook targets)
- **F11** `pkg/git/git.go` — `EnsureWithin`: add path separator guard to prevent sibling-directory escape (`/data/repos-evil` no longer matches `/data/repos`)
- **F12** `pkg/ssh/middleware.go` — Filter `s.Environ()` to `GIT_*`/`LC_*`/`TERM` allowlist before verbose logging

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./pkg/backend/... ./pkg/web/... ./pkg/git/... ./pkg/webhook/... ./pkg/ssh/...` — all pass
- [ ] Manually verify existing passwords still authenticate after bcrypt salt change (bcrypt re-hashes are not needed — the existing hashes contain `password+saltySalt` but new hashes will be `password`; **existing users need to reset passwords or the old hashes must be migrated**)

> ⚠️ **Breaking change for passwords**: The bcrypt change removes the static pepper. Users with existing passwords hashed with the old `password+"salty-soft-serve"` pattern will fail to authenticate. See migration note below.

### Migration note
If you have existing users with passwords set, run a one-time admin reset or provide a migration script that re-hashes with the new scheme. New user accounts created after this change are unaffected.

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)