### PR TITLE
harden(security): second-pass hardening — env isolation, timing oracle, security headers

### DIFF
--- a/cmd/soft/hook/hook.go
+++ b/cmd/soft/hook/hook.go
@@ -168,5 +168,7 @@ func runCommand(ctx context.Context, in io.Reader, out io.Writer, err io.Writer,
 	cmd.Stdin = in
 	cmd.Stdout = out
 	cmd.Stderr = err
+	cfg := config.FromContext(ctx)
+	cmd.Env = cfg.Environ()
 	return cmd.Run()
 }

--- a/pkg/backend/auth.go
+++ b/pkg/backend/auth.go
@@ -9,8 +9,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-const saltySalt = "salty-soft-serve"
-
 // HashPassword hashes the password using bcrypt.
 func HashPassword(password string) (string, error) {
 	crypt, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
@@ -40,6 +38,6 @@ func GenerateToken() string {
 
 // HashToken hashes the token using sha256.
 func HashToken(token string) string {
-	sum := sha256.Sum256([]byte(token + saltySalt))
+	sum := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(sum[:])
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -146,6 +146,17 @@ func (d *GitDaemon) fatal(c net.Conn, err error) {
 	}
 }
 
+// sanitizeParamValue rejects values containing newlines, nulls, or other
+// control characters that could corrupt the GIT_PROTOCOL env var.
+func sanitizeParamValue(s string) (string, bool) {
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return "", false
+		}
+	}
+	return s, true
+}
+
 // handleClient handles a git protocol client.
 func (d *GitDaemon) handleClient(conn net.Conn) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -284,15 +295,32 @@ func (d *GitDaemon) handleClient(conn net.Conn) {
 		}
 
 		// Add git protocol environment variable.
+		// Only the "version" key is accepted; values are checked for control characters.
 		if len(extraParams) > 0 {
 			var gitProto string
 			for k, v := range extraParams {
+				if k != "version" {
+					d.logger.Warnf("git: ignoring unknown extra param key %q", k)
+					continue
+				}
+				sk, ok := sanitizeParamValue(k)
+				if !ok {
+					d.logger.Warnf("git: dropping extra param with unsafe key %q", k)
+					continue
+				}
+				sv, ok := sanitizeParamValue(v)
+				if !ok {
+					d.logger.Warnf("git: dropping extra param with unsafe value for key %q", k)
+					continue
+				}
 				if len(gitProto) > 0 {
 					gitProto += ":"
 				}
-				gitProto += k + "=" + v
+				gitProto += sk + "=" + sv
 			}
-			envs = append(envs, "GIT_PROTOCOL="+gitProto)
+			if gitProto != "" {
+				envs = append(envs, "GIT_PROTOCOL="+gitProto)
+			}
 		}
 
 		envs = append(envs, d.cfg.Environ()...)

--- a/pkg/git/service.go
+++ b/pkg/git/service.go
@@ -95,10 +95,16 @@ func gitServiceHandler(ctx context.Context, svc Service, scmd ServiceCommand) er
 
 	cmd.Args = append(cmd.Args, ".")
 
-	cmd.Env = os.Environ()
-	if len(scmd.Env) > 0 {
-		cmd.Env = append(cmd.Env, scmd.Env...)
+	// Build a minimal environment for the git subprocess.
+	// Start with only HOME and PATH; callers append SOFT_SERVE_* vars via scmd.Env.
+	minimal := []string{
+		"HOME=" + os.Getenv("HOME"),
+		"PATH=" + os.Getenv("PATH"),
 	}
+	if v := os.Getenv("GIT_EXEC_PATH"); v != "" {
+		minimal = append(minimal, "GIT_EXEC_PATH="+v)
+	}
+	cmd.Env = append(minimal, scmd.Env...)
 
 	if scmd.CmdFunc != nil {
 		scmd.CmdFunc(cmd)

--- a/pkg/jobs/mirror.go
+++ b/pkg/jobs/mirror.go
@@ -94,7 +94,7 @@ func (m mirrorPull) Func(ctx context.Context) func() {
 						// in ImportRepository already sets Timeout: -1 for the
 						// same reason. git-module RunInDirWithOptions only applies
 						// a deadline when timeout > 0, so -1 is safe here.
-						cmd := git.NewCommand(args...).WithContext(ctx).WithTimeout(-1)
+						cmd := git.NewCommand(args...).WithContext(ctx).WithTimeout(30 * 60)
 						cmd.AddEnvs(sshEnv)
 
 						if _, err := cmd.RunInDir(r.Path); err != nil {

--- a/pkg/jwk/jwk.go
+++ b/pkg/jwk/jwk.go
@@ -2,6 +2,7 @@ package jwk
 
 import (
 	"crypto"
+	"crypto/ed25519"
 	"crypto/sha256"
 	"fmt"
 
@@ -37,8 +38,14 @@ func NewPair(cfg *config.Config) (Pair, error) {
 		return Pair{}, err
 	}
 
-	sum := sha256.Sum256(kp.RawPrivateKey())
-	kid := fmt.Sprintf("%x", sum)
+	// Derive kid from the public key bytes (Ed25519 public key is a []byte).
+	var kidBytes []byte
+	if pub, ok := kp.CryptoPublicKey().(ed25519.PublicKey); ok {
+		kidBytes = pub
+	} else {
+		kidBytes = kp.RawPrivateKey()
+	}
+	kid := fmt.Sprintf("%x", sha256.Sum256(kidBytes))
 	jwk := jose.JSONWebKey{
 		Key:       kp.CryptoPublicKey(),
 		KeyID:     kid,

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -24,30 +25,42 @@ func NewLocalStorage(root string) *LocalStorage {
 
 // Delete implements Storage.
 func (l *LocalStorage) Delete(name string) error {
-	name = l.fixPath(name)
-	return os.Remove(name)
+	p, err := l.fixPath(name)
+	if err != nil {
+		return err
+	}
+	return os.Remove(p)
 }
 
 // Open implements Storage.
 func (l *LocalStorage) Open(name string) (Object, error) {
-	name = l.fixPath(name)
-	return os.Open(name)
+	p, err := l.fixPath(name)
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(p)
 }
 
 // Stat implements Storage.
 func (l *LocalStorage) Stat(name string) (fs.FileInfo, error) {
-	name = l.fixPath(name)
-	return os.Stat(name)
+	p, err := l.fixPath(name)
+	if err != nil {
+		return nil, err
+	}
+	return os.Stat(p)
 }
 
 // Put implements Storage.
 func (l *LocalStorage) Put(name string, r io.Reader) (int64, error) {
-	name = l.fixPath(name)
-	if err := os.MkdirAll(filepath.Dir(name), os.ModePerm); err != nil {
+	p, err := l.fixPath(name)
+	if err != nil {
+		return 0, err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), os.ModePerm); err != nil {
 		return 0, err
 	}
 
-	f, err := os.Create(name)
+	f, err := os.Create(p)
 	if err != nil {
 		return 0, err
 	}
@@ -57,8 +70,11 @@ func (l *LocalStorage) Put(name string, r io.Reader) (int64, error) {
 
 // Exists implements Storage.
 func (l *LocalStorage) Exists(name string) (bool, error) {
-	name = l.fixPath(name)
-	_, err := os.Stat(name)
+	p, err := l.fixPath(name)
+	if err != nil {
+		return false, err
+	}
+	_, err = os.Stat(p)
 	if err == nil {
 		return true, nil
 	}
@@ -70,28 +86,37 @@ func (l *LocalStorage) Exists(name string) (bool, error) {
 
 // Rename implements Storage.
 func (l *LocalStorage) Rename(oldName, newName string) error {
-	oldName = l.fixPath(oldName)
-	newName = l.fixPath(newName)
-	if err := os.MkdirAll(filepath.Dir(newName), os.ModePerm); err != nil {
+	oldPath, err := l.fixPath(oldName)
+	if err != nil {
+		return err
+	}
+	newPath, err := l.fixPath(newName)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(newPath), os.ModePerm); err != nil {
 		return err
 	}
 
 	// If destination already exists the object was uploaded concurrently.
 	// Remove the temp file and return success — the stored copy is authoritative.
-	if _, err := os.Stat(newName); err == nil {
-		_ = os.Remove(oldName)
+	if _, err := os.Stat(newPath); err == nil {
+		_ = os.Remove(oldPath)
 		return nil
 	}
 
-	return os.Rename(oldName, newName)
+	return os.Rename(oldPath, newPath)
 }
 
-// Replace all slashes with the OS-specific separator
-func (l LocalStorage) fixPath(path string) string {
+// fixPath resolves the storage-relative path and verifies it stays within the root.
+// Replace all slashes with the OS-specific separator.
+func (l LocalStorage) fixPath(path string) (string, error) {
 	path = strings.ReplaceAll(path, "/", string(os.PathSeparator))
-	if !filepath.IsAbs(path) {
-		return filepath.Join(l.root, path)
+	p := filepath.Join(l.root, path)
+	// Ensure the resolved path is within the storage root.
+	root := l.root + string(filepath.Separator)
+	if !strings.HasPrefix(p, root) && p != l.root {
+		return "", fmt.Errorf("storage: path %q escapes root", path)
 	}
-
-	return path
+	return p, nil
 }

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/soft-serve/pkg/config"
 	"github.com/charmbracelet/soft-serve/pkg/proto"
 	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // authenticate authenticates the user from the request.
@@ -31,13 +32,22 @@ func authenticate(r *http.Request) (proto.User, error) {
 // ErrInvalidPassword is returned when the password is invalid.
 var ErrInvalidPassword = errors.New("invalid password")
 
+// dummyHash is a bcrypt hash used to equalize timing when user doesn't exist.
+// This prevents username enumeration via timing differences.
+const dummyHash = "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy"
+
 func parseUsernamePassword(ctx context.Context, username, password string) (proto.User, error) {
 	logger := log.FromContext(ctx)
 	be := backend.FromContext(ctx)
 
 	if username != "" && password != "" {
 		user, err := be.User(ctx, username)
-		if err == nil && user != nil && backend.VerifyPassword(password, user.Password()) {
+		if err != nil {
+			// Run a dummy bcrypt comparison to prevent username enumeration via timing.
+			_ = bcrypt.CompareHashAndPassword([]byte(dummyHash), []byte(password))
+			return nil, ErrInvalidPassword
+		}
+		if user != nil && backend.VerifyPassword(password, user.Password()) {
 			return user, nil
 		}
 
@@ -47,7 +57,11 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 			return user, nil
 		}
 
-		logger.Error("invalid password or token", "username", username, "err", err)
+		logUsername := username
+		if len(logUsername) > 20 {
+			logUsername = logUsername[:20] + "…"
+		}
+		logger.Error("invalid password or token", "username", logUsername, "err", err)
 		return nil, ErrInvalidPassword
 	} else if username != "" {
 		// Try to authenticate using access token as the username

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -341,7 +341,8 @@ func serviceLfsBasicUpload(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxLFSObjectSize)
 
 	pointer := lfs.Pointer{Oid: oid}
-	if _, err := strg.Put(path.Join("objects", pointer.RelativePath()), r.Body); err != nil {
+	n, err := strg.Put(path.Join("objects", pointer.RelativePath()), r.Body)
+	if err != nil {
 		logger.Error("error writing object", "oid", oid, "err", err)
 		renderJSON(w, http.StatusInternalServerError, lfs.ErrorResponse{
 			Message: "internal server error",
@@ -349,16 +350,7 @@ func serviceLfsBasicUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	size, err := strconv.ParseInt(r.Header.Get("Content-Length"), 10, 64)
-	if err != nil {
-		logger.Error("error parsing content length", "err", err)
-		renderJSON(w, http.StatusBadRequest, lfs.ErrorResponse{
-			Message: "invalid content length",
-		})
-		return
-	}
-
-	if err := datastore.CreateLFSObject(ctx, dbx, repo.ID(), oid, size); err != nil {
+	if err := datastore.CreateLFSObject(ctx, dbx, repo.ID(), oid, n); err != nil {
 		if errors.Is(err, db.ErrDuplicateKey) {
 			// A concurrent upload for the same OID already committed the record;
 			// treat as idempotent success (git-lfs sends parallel PUTs for large pushes).

--- a/pkg/web/goget.go
+++ b/pkg/web/goget.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"text/template"
+	"html/template"
 
 	"charm.land/log/v2"
 	"github.com/charmbracelet/soft-serve/pkg/backend"

--- a/pkg/web/http.go
+++ b/pkg/web/http.go
@@ -31,8 +31,10 @@ func NewHTTPServer(ctx context.Context) (*HTTPServer, error) {
 			Addr:              cfg.HTTP.ListenAddr,
 			Handler:           NewRouter(ctx),
 			ReadHeaderTimeout: time.Second * 10,
-			WriteTimeout:      5 * time.Minute,
-			IdleTimeout:       time.Second * 10,
+			// WriteTimeout is intentionally not set here: git pack-objects streams can
+			// take hours for large repositories, and a fixed deadline would kill legitimate
+			// large clones/pushes. Connection idle timeouts are enforced by IdleTimeout.
+			IdleTimeout: time.Second * 10,
 			MaxHeaderBytes:    http.DefaultMaxHeaderBytes,
 			ErrorLog:          logger.StandardLog(log.StandardLogOptions{ForceLevel: log.ErrorLevel}),
 		},

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -10,6 +10,17 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// securityHeadersMiddleware sets defensive HTTP response headers.
+func securityHeadersMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Frame-Options", "DENY")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
+		next.ServeHTTP(w, r)
+	})
+}
+
 // NewRouter returns a new HTTP router.
 func NewRouter(ctx context.Context) http.Handler {
 	logger := log.FromContext(ctx).WithPrefix("http")
@@ -32,6 +43,7 @@ func NewRouter(ctx context.Context) http.Handler {
 	h = gitSuffixMiddleware(cfg)(h)
 	h = handlers.CompressHandler(h)
 	h = handlers.RecoveryHandler()(h)
+	h = securityHeadersMiddleware(h)
 
 	h = handlers.CORS(handlers.AllowedHeaders(cfg.HTTP.CORS.AllowedHeaders),
 		handlers.AllowedOrigins(cfg.HTTP.CORS.AllowedOrigins),


### PR DESCRIPTION
## Summary

Second-pass security hardening applying 13 fixes from a follow-up STRIDE + OWASP audit. Continues from PR #61.

## Changes

### MUST-FIX
- **F1** `pkg/git/service.go` — git subprocesses now start from a minimal `HOME`/`PATH` environment; DB credentials and other server env vars no longer leak to git hooks via `os.Environ()`
- **F2** `pkg/backend/auth.go` — static `saltySalt` constant fully removed; `HashToken` now hashes the bare token with SHA-256 (token entropy is the security, not the constant)

### SHOULD-FIX
- **F3** `pkg/web/auth.go` — dummy bcrypt run for unknown users to equalize timing and prevent username enumeration; username truncated to 20 chars in failed-auth log
- **F4** `pkg/jobs/mirror.go` — `WithTimeout(-1)` → `WithTimeout(1800)` (30-minute per-repo cap; prevents hung goroutines from exhausting the mirror worker pool)
- **F5** `pkg/web/http.go` — `WriteTimeout` removed (5-minute global deadline was killing large git pack transfers on slow connections)
- **F6** `pkg/daemon/daemon.go` — git daemon `GIT_PROTOCOL` built from allowlisted + control-char-stripped `extraParams` (prevents newline injection from malicious pktline clients)
- **F7** `pkg/storage/local.go` — `fixPath` now rejects absolute paths that escape the storage root via `EnsureWithin`-style check
- **F8** `pkg/web/goget.go` — `text/template` → `html/template` (auto-escaping for go-get HTML page)
- **F9** `pkg/web/server.go` — `securityHeadersMiddleware` added: `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'`
- **F10** `cmd/soft/hook/hook.go` — custom hook subprocess now uses `cfg.Environ()` instead of inheriting full server environment
- **F11** `pkg/jwk/jwk.go` — JWK `kid` now derived from Ed25519 public key bytes, not private key
- **F12** `pkg/web/git_lfs.go` — LFS object size in DB now taken from actual bytes written by `strg.Put`, not from the client-supplied `Content-Length` header

## Test plan
- [x] `go build ./...` — clean
- [x] `go test -count=1 ./pkg/backend/... ./pkg/web/... ./pkg/git/... ./pkg/daemon/...` — all pass

> ⚠️ **Breaking change — access tokens**: `HashToken` no longer appends the static salt. Existing access tokens in the DB were stored as `sha256(token+"salty-soft-serve")`. After this change they are stored as `sha256(token)`. All existing tokens will stop working and users must regenerate them.

Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)