### PR TITLE
harden(security): third-pass — LFS lock scope, Git-Protocol sanitization, sendFile guard

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -516,7 +516,9 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	c.HTTP.CORS.AllowedOrigins = append([]string{c.HTTP.PublicURL}, c.HTTP.CORS.AllowedOrigins...)
+	if len(c.HTTP.CORS.AllowedOrigins) == 0 || c.HTTP.CORS.AllowedOrigins[0] != c.HTTP.PublicURL {
+		c.HTTP.CORS.AllowedOrigins = append([]string{c.HTTP.PublicURL}, c.HTTP.CORS.AllowedOrigins...)
+	}
 
 	return nil
 }

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -452,7 +452,14 @@ func serviceRpc(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(http.StatusOK)
 
-	version := r.Header.Get("Git-Protocol")
+	gitProtocol := r.Header.Get("Git-Protocol")
+	// Sanitize: reject any control characters to prevent env var injection.
+	for _, c := range gitProtocol {
+		if c < 0x20 || c == 0x7f {
+			gitProtocol = ""
+			break
+		}
+	}
 
 	var stdout bytes.Buffer
 	cmd := git.ServiceCommand{
@@ -477,10 +484,8 @@ func serviceRpc(w http.ResponseWriter, r *http.Request) {
 			"SOFT_SERVE_USERNAME=" + user.Username(),
 		}...)
 	}
-	if len(version) != 0 {
-		cmd.Env = append(cmd.Env, []string{
-			fmt.Sprintf("GIT_PROTOCOL=%s", version),
-		}...)
+	if gitProtocol != "" {
+		cmd.Env = append(cmd.Env, "GIT_PROTOCOL="+gitProtocol)
 	}
 
 	var (
@@ -563,6 +568,13 @@ func getInfoRefs(w http.ResponseWriter, r *http.Request) {
 	dir, repoName, file := mux.Vars(r)["dir"], mux.Vars(r)["repo"], mux.Vars(r)["file"]
 	service := getServiceType(r)
 	protocol := r.Header.Get("Git-Protocol")
+	// Sanitize: reject any control characters to prevent env var injection.
+	for _, c := range protocol {
+		if c < 0x20 || c == 0x7f {
+			protocol = ""
+			break
+		}
+	}
 
 	gitHttpUploadCounter.WithLabelValues(repoName, file).Inc()
 
@@ -587,8 +599,8 @@ func getInfoRefs(w http.ResponseWriter, r *http.Request) {
 				"SOFT_SERVE_USERNAME=" + user.Username(),
 			}...)
 		}
-		if len(protocol) != 0 {
-			cmd.Env = append(cmd.Env, fmt.Sprintf("GIT_PROTOCOL=%s", protocol))
+		if protocol != "" {
+			cmd.Env = append(cmd.Env, "GIT_PROTOCOL="+protocol)
 		}
 
 		var version int
@@ -648,6 +660,13 @@ func getTextFile(w http.ResponseWriter, r *http.Request) {
 func sendFile(contentType string, w http.ResponseWriter, r *http.Request) {
 	dir, file := mux.Vars(r)["dir"], mux.Vars(r)["file"]
 	reqFile := filepath.Join(dir, file)
+
+	// Guard against path traversal.
+	root := dir + string(filepath.Separator)
+	if !strings.HasPrefix(reqFile, root) {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
 
 	f, err := os.Stat(reqFile)
 	if os.IsNotExist(err) {

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -235,6 +235,7 @@ func serviceLfsBatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	batchResponse.Objects = objects
+	w.Header().Set("Cache-Control", "no-store, private")
 	renderJSON(w, http.StatusOK, batchResponse)
 }
 
@@ -620,6 +621,14 @@ func serviceLfsLocksGet(w http.ResponseWriter, r *http.Request) {
 			logger.Error("error getting lock", "err", err)
 			renderJSON(w, http.StatusInternalServerError, lfs.ErrorResponse{
 				Message: "internal server error",
+			})
+			return
+		}
+
+		// Scope check: reject locks belonging to other repos.
+		if lock.RepoID != repo.ID() {
+			renderJSON(w, http.StatusNotFound, lfs.ErrorResponse{
+				Message: "lock not found",
 			})
 			return
 		}


### PR DESCRIPTION
## Summary

Third-pass security hardening with 6 targeted fixes. Continues from PR #61 and #62.

## Changes

- **F1** `pkg/web/git_lfs.go` — LFS lock `GET ?id=N` now verifies `lock.RepoID == repo.ID()` before responding; prevents a user with access to repo A from reading lock paths belonging to private repo B
- **F2** `pkg/web/git.go (serviceRpc)` — `Git-Protocol` HTTP header sanitized before becoming `GIT_PROTOCOL` env var; control characters (`< 0x20` or `0x7f`) cause the header to be dropped
- **F3** `pkg/web/git.go (getInfoRefs)` — same sanitization in the git advertisement path
- **F4** `pkg/web/git.go (sendFile)` — `strings.HasPrefix(reqFile, dir+sep)` guard added before `os.Stat`; defense-in-depth against path traversal in static git object serving
- **F5** `pkg/web/git_lfs.go` — `Cache-Control: no-store, private` added to LFS batch response; prevents caching of auth tokens in `Link.Header` by intermediate proxies
- **F6** `pkg/config/config.go` — `AllowedOrigins` prepend is now idempotent; repeated `Validate()` calls no longer grow the slice

## Test plan
- [x] `go build ./...` — clean
- [x] `go test -count=1 ./pkg/web/... ./pkg/config/...` — all pass

Closes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)