### PR TITLE
fix: review-loop round 3 — LFS verify, git:// SSRF, auth echo, per-IP daemon cap, dead code

### DIFF
--- a/pkg/backend/cache.go
+++ b/pkg/backend/cache.go
@@ -30,6 +30,3 @@ func (c *cache) Delete(repo string) {
 	c.repos.Remove(repo)
 }
 
-func (c *cache) Len() int {
-	return c.repos.Len()
-}

--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -59,6 +59,15 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 				b.logger.Warn("push mirror: blocked file:// URL", "url", m.RemoteURL)
 				continue // skip this mirror
 			}
+			if scheme == "git" {
+				b.logger.Warn("push mirror: blocked git:// URL", "url", m.RemoteURL)
+				continue // skip this mirror
+			}
+			host := u.Hostname()
+			if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+				b.logger.Warn("push mirror: blocked loopback address", "url", m.RemoteURL)
+				continue // skip this mirror
+			}
 		}
 		sem <- struct{}{} // acquire
 		go func(m models.PushMirror) {

--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -137,6 +137,10 @@ func (d *Backend) ImportRepository(_ context.Context, name string, user proto.Us
 
 	rp := filepath.Join(d.repoPath(name))
 
+	if d.manager == nil {
+		return nil, fmt.Errorf("import repository: no manager configured")
+	}
+
 	tid := "import:" + name
 	if d.manager.Exists(tid) {
 		return nil, task.ErrAlreadyStarted

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -59,6 +59,7 @@ type GitDaemon struct {
 	listeners []net.Listener
 	liMu      sync.Mutex
 	limiter   *ratelimit.IPLimiter
+	ipConns   sync.Map // map[string]*int32 — active connections per IP
 }
 
 // NewGitDaemon returns a new Git daemon.
@@ -135,8 +136,24 @@ func (d *GitDaemon) Serve(listener net.Listener) error {
 			continue
 		}
 
+		// Per-IP connection cap: reject IPs with >= 10 concurrent connections.
+		const maxConnsPerIP = 10
+		remoteIP, _, _ := net.SplitHostPort(conn.RemoteAddr().String())
+		if remoteIP == "" {
+			remoteIP = conn.RemoteAddr().String()
+		}
+		val, _ := d.ipConns.LoadOrStore(remoteIP, new(int32))
+		ipCount := val.(*int32)
+		if atomic.AddInt32(ipCount, 1) > maxConnsPerIP {
+			atomic.AddInt32(ipCount, -1)
+			d.logger.Debugf("git: per-IP connection limit reached, closing %s", conn.RemoteAddr())
+			d.fatal(conn, git.ErrMaxConnections)
+			continue
+		}
+
 		d.wg.Add(1)
 		go func() {
+			defer atomic.AddInt32(ipCount, -1)
 			d.handleClient(conn)
 			d.wg.Done()
 		}()

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -20,7 +20,7 @@ func authenticate(r *http.Request) (proto.User, error) {
 	// Prefer the Authorization header
 	user, err := parseAuthHdr(r)
 	if err != nil || user == nil {
-		if errors.Is(err, ErrInvalidToken) || errors.Is(err, ErrInvalidPassword) {
+		if errors.Is(err, errInvalidToken) || errors.Is(err, errInvalidPassword) {
 			return nil, err
 		}
 		return nil, proto.ErrUserNotFound
@@ -29,8 +29,8 @@ func authenticate(r *http.Request) (proto.User, error) {
 	return user, nil
 }
 
-// ErrInvalidPassword is returned when the password is invalid.
-var ErrInvalidPassword = errors.New("invalid password")
+// errInvalidPassword is returned when the password is invalid.
+var errInvalidPassword = errors.New("invalid password")
 
 // dummyHash is a bcrypt hash used to equalize timing when user doesn't exist.
 // This prevents username enumeration via timing differences.
@@ -45,7 +45,7 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 		if err != nil {
 			// Run a dummy bcrypt comparison to prevent username enumeration via timing.
 			_ = bcrypt.CompareHashAndPassword([]byte(dummyHash), []byte(password))
-			return nil, ErrInvalidPassword
+			return nil, errInvalidPassword
 		}
 		if user != nil && backend.VerifyPassword(password, user.Password()) {
 			return user, nil
@@ -62,7 +62,7 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 			logUsername = logUsername[:20] + "…"
 		}
 		logger.Error("invalid password or token", "username", logUsername, "err", err)
-		return nil, ErrInvalidPassword
+		return nil, errInvalidPassword
 	} else if username != "" {
 		// Try to authenticate using access token as the username
 		logUser := username
@@ -76,20 +76,20 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 		}
 
 		logger.Error("failed to get user", "err", err)
-		return nil, ErrInvalidToken
+		return nil, errInvalidToken
 	}
 
 	return nil, proto.ErrUserNotFound
 }
 
-// ErrInvalidHeader is returned when the authorization header is invalid.
-var ErrInvalidHeader = errors.New("invalid authorization header")
+// errInvalidHeader is returned when the authorization header is invalid.
+var errInvalidHeader = errors.New("invalid authorization header")
 
 func parseAuthHdr(r *http.Request) (proto.User, error) {
 	// Check for auth header
 	header := r.Header.Get("Authorization")
 	if header == "" {
-		return nil, ErrInvalidHeader
+		return nil, errInvalidHeader
 	}
 
 	ctx := r.Context()
@@ -141,15 +141,15 @@ func parseAuthHdr(r *http.Request) (proto.User, error) {
 	default:
 		username, password, ok := r.BasicAuth()
 		if !ok {
-			return nil, ErrInvalidHeader
+			return nil, errInvalidHeader
 		}
 
 		return parseUsernamePassword(ctx, username, password)
 	}
 }
 
-// ErrInvalidToken is returned when a token is invalid.
-var ErrInvalidToken = errors.New("invalid token")
+// errInvalidToken is returned when a token is invalid.
+var errInvalidToken = errors.New("invalid token")
 
 func parseJWT(ctx context.Context, bearer string) (*jwt.RegisteredClaims, error) {
 	cfg := config.FromContext(ctx)
@@ -177,12 +177,12 @@ func parseJWT(ctx context.Context, bearer string) (*jwt.RegisteredClaims, error)
 	)
 	if err != nil {
 		logger.Error("failed to parse jwt", "err", err)
-		return nil, ErrInvalidToken
+		return nil, errInvalidToken
 	}
 
 	claims, ok := token.Claims.(*jwt.RegisteredClaims)
 	if !token.Valid || !ok {
-		return nil, ErrInvalidToken
+		return nil, errInvalidToken
 	}
 
 	return claims, nil

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -274,7 +274,7 @@ func withAccess(next http.Handler) http.HandlerFunc {
 		user, err := authenticate(r)
 		if err != nil {
 			switch {
-			case errors.Is(err, ErrInvalidToken):
+			case errors.Is(err, errInvalidToken):
 			case errors.Is(err, proto.ErrUserNotFound):
 			default:
 				logger.Error("failed to authenticate", "err", err)
@@ -343,7 +343,7 @@ func withAccess(next http.Handler) http.HandlerFunc {
 				// If the repo doesn't exist, return 404
 				renderNotFound(w, r)
 				return
-			} else if errors.Is(err, ErrInvalidToken) || errors.Is(err, ErrInvalidPassword) {
+			} else if errors.Is(err, errInvalidToken) || errors.Is(err, errInvalidPassword) {
 				// return 403 when bad credentials are provided
 				renderForbidden(w, r)
 				return
@@ -398,7 +398,7 @@ func withAccess(next http.Handler) http.HandlerFunc {
 					renderJSON(w, http.StatusNotFound, lfs.ErrorResponse{
 						Message: "repository not found",
 					})
-				} else if errors.Is(err, ErrInvalidToken) || errors.Is(err, ErrInvalidPassword) {
+				} else if errors.Is(err, errInvalidToken) || errors.Is(err, errInvalidPassword) {
 					renderJSON(w, http.StatusForbidden, lfs.ErrorResponse{
 						Message: "bad credentials",
 					})
@@ -416,7 +416,7 @@ func withAccess(next http.Handler) http.HandlerFunc {
 		case r.URL.Query().Get("go-get") == "1" && (accessLevel >= access.ReadOnlyAccess || cfg.AllowPublicGoGet):
 			// Allow go-get requests to passthrough.
 			break
-		case errors.Is(err, ErrInvalidToken), errors.Is(err, ErrInvalidPassword):
+		case errors.Is(err, errInvalidToken), errors.Is(err, errInvalidPassword):
 			// return 403 when bad credentials are provided
 			renderForbidden(w, r)
 			return

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -143,11 +143,6 @@ func serviceLfsBatch(w http.ResponseWriter, r *http.Request) {
 				download := &lfs.Link{
 					Href: fmt.Sprintf("%s/%s", baseHref, o.Oid),
 				}
-				if auth := r.Header.Get("Authorization"); auth != "" {
-					download.Header = map[string]string{
-						"Authorization": auth,
-					}
-				}
 
 				objects = append(objects, &lfs.ObjectResponse{
 					Pointer: o,
@@ -209,12 +204,6 @@ func serviceLfsBatch(w http.ResponseWriter, r *http.Request) {
 				}
 				verify := &lfs.Link{
 					Href: fmt.Sprintf("%s/verify", baseHref),
-				}
-				if auth := r.Header.Get("Authorization"); auth != "" {
-					upload.Header["Authorization"] = auth
-					verify.Header = map[string]string{
-						"Authorization": auth,
-					}
 				}
 
 				objects = append(objects, &lfs.ObjectResponse{
@@ -438,7 +427,8 @@ func serviceLfsBasicVerify(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if pointer.IsValid() && stat.Size() == pointer.Size {
-			renderStatus(http.StatusOK)(w, nil)
+			w.Header().Set("Content-Type", "application/vnd.git-lfs+json")
+			renderJSON(w, http.StatusOK, map[string]string{"message": "verified"})
 			return
 		}
 	} else if errors.Is(err, fs.ErrNotExist) {

--- a/pkg/web/goget.go
+++ b/pkg/web/goget.go
@@ -26,11 +26,11 @@ var repoIndexHTMLTpl = template.Must(template.New("index").Parse(`<!DOCTYPE html
 <html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <meta http-equiv="refresh" content="0; url=https://godoc.org/{{ .ImportRoot }}/{{.Repo}}">
+    <meta http-equiv="refresh" content="0; url=https://pkg.go.dev/{{ .ImportRoot }}/{{.Repo}}">
     <meta name="go-import" content="{{ .ImportRoot }}/{{ .Repo }} git {{ .CloneURL }}">
 </head>
 <body>
-Redirecting to docs at <a href="https://godoc.org/{{ .ImportRoot }}/{{ .Repo }}">godoc.org/{{ .ImportRoot }}/{{ .Repo }}</a>...
+Redirecting to docs at <a href="https://pkg.go.dev/{{ .ImportRoot }}/{{ .Repo }}">pkg.go.dev/{{ .ImportRoot }}/{{ .Repo }}</a>...
 </body>
 </html>
 `))


### PR DESCRIPTION
## Summary
- Fix `serviceLfsBasicVerify` missing terminal JSON response (MUST-FIX)
- Block `git://` + loopback SSRF in push mirrors (SHOULD-FIX)
- Remove Authorization header echo from LFS batch responses (SHOULD-FIX)
- Guard against `nil` manager panic in `ImportRepository` (SHOULD-FIX)
- Add per-IP connection cap (10) to git daemon (SHOULD-FIX)
- Unexport `ErrInvalidHeader/Password/Token` in pkg/web (NIT)
- Replace defunct `godoc.org` with `pkg.go.dev` (NIT)
- Remove dead `Len()` method from cache (NIT)

Closes #837