### PR TITLE
fix: review-loop round 4 — Prometheus counters, username validation, LFS lock scope, timing oracle

### DIFF
--- a/pkg/backend/user.go
+++ b/pkg/backend/user.go
@@ -333,6 +333,11 @@ func (d *Backend) SetUsername(ctx context.Context, username string, newUsername 
 		return err
 	}
 
+	newUsername = strings.ToLower(newUsername)
+	if err := utils.ValidateUsername(newUsername); err != nil {
+		return err
+	}
+
 	return db.WrapError(
 		d.db.TransactionContext(ctx, func(tx *db.Tx) error {
 			return d.store.SetUsernameByUsername(ctx, tx, username, newUsername)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -104,7 +104,6 @@ func (d *GitDaemon) Serve(listener net.Listener) error {
 	d.listeners = append(d.listeners, listener)
 	d.liMu.Unlock()
 
-	var tempDelay time.Duration
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
@@ -113,18 +112,6 @@ func (d *GitDaemon) Serve(listener net.Listener) error {
 				return ErrServerClosed
 			default:
 				d.logger.Debugf("git: error accepting connection: %v", err)
-			}
-			if ne, ok := err.(net.Error); ok && ne.Temporary() {
-				if tempDelay == 0 {
-					tempDelay = 5 * time.Millisecond
-				} else {
-					tempDelay *= 2
-				}
-				if max := 1 * time.Second; tempDelay > max { //nolint:revive
-					tempDelay = max
-				}
-				time.Sleep(tempDelay)
-				continue
 			}
 			return err
 		}
@@ -367,7 +354,7 @@ func (d *GitDaemon) handleClient(conn net.Conn) {
 			return
 		}
 
-		counter.WithLabelValues(name)
+		counter.WithLabelValues(name).Inc()
 	}
 }
 

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -65,7 +65,11 @@ func (il *IPLimiter) Allow(ip string) bool {
 }
 
 func (il *IPLimiter) cleanup() {
-	ticker := time.NewTicker(time.Minute)
+	cleanupInterval := il.ttl / 5
+	if cleanupInterval < time.Minute {
+		cleanupInterval = time.Minute
+	}
+	ticker := time.NewTicker(cleanupInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -45,6 +45,9 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 		if err != nil {
 			// Run a dummy bcrypt comparison to prevent username enumeration via timing.
 			_ = bcrypt.CompareHashAndPassword([]byte(dummyHash), []byte(password))
+			// Also attempt token lookup so the not-found and wrong-password paths
+			// do the same amount of work.
+			_, _ = be.UserByAccessToken(ctx, password)
 			return nil, errInvalidPassword
 		}
 		if user != nil && backend.VerifyPassword(password, user.Password()) {

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -443,7 +443,7 @@ func serviceRpc(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if service == git.ReceivePackService {
-		gitHttpReceiveCounter.WithLabelValues(repoName)
+		gitHttpReceiveCounter.WithLabelValues(repoName).Inc()
 	}
 
 	w.Header().Set("Content-Type", fmt.Sprintf("application/x-%s-result", service))
@@ -743,7 +743,7 @@ const oneYearSeconds = 31536000
 func hdrCacheForever(w http.ResponseWriter) {
 	now := time.Now().Unix()
 	expires := now + oneYearSeconds
-	w.Header().Set("Date", fmt.Sprintf("%d", now))
-	w.Header().Set("Expires", fmt.Sprintf("%d", expires))
+	w.Header().Set("Date", time.Unix(now, 0).UTC().Format(http.TimeFormat))
+	w.Header().Set("Expires", time.Unix(expires, 0).UTC().Format(http.TimeFormat))
 	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", oneYearSeconds))
 }

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -295,6 +295,9 @@ func serviceLfsBasicDownload(w http.ResponseWriter, r *http.Request) {
 
 // PUT: /<repo>.git/info/lfs/objects/basic/<oid>
 func serviceLfsBasicUpload(w http.ResponseWriter, r *http.Request) {
+	const maxLFSObjectSize = 5 << 30 // 5 GiB
+	r.Body = http.MaxBytesReader(w, r.Body, maxLFSObjectSize)
+
 	if !isBinary(r) {
 		renderJSON(w, http.StatusUnsupportedMediaType, lfs.ErrorResponse{
 			Message: "invalid content type",
@@ -337,9 +340,6 @@ func serviceLfsBasicUpload(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-
-	const maxLFSObjectSize = 5 << 30 // 5 GiB
-	r.Body = http.MaxBytesReader(w, r.Body, maxLFSObjectSize)
 
 	pointer := lfs.Pointer{Oid: oid}
 	n, err := strg.Put(path.Join("objects", pointer.RelativePath()), r.Body)
@@ -892,6 +892,13 @@ func serviceLfsLocksDelete(w http.ResponseWriter, r *http.Request) {
 		renderJSON(w, http.StatusNotFound, lfs.ErrorResponse{
 			Message: "lock not found",
 		})
+		return
+	}
+
+	if lock.RepoID != repo.ID() {
+		renderJSON(w, http.StatusNotFound, struct {
+			Message string `json:"message"`
+		}{"lock not found"})
 		return
 	}
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/charmbracelet/soft-serve/git"
 	"github.com/charmbracelet/soft-serve/pkg/db"
@@ -98,7 +99,7 @@ func SendWebhook(ctx context.Context, w models.Webhook, event Event, payload int
 		headers.Add("X-SoftServe-Signature", "sha256="+hex.EncodeToString(sig.Sum(nil)))
 	}
 
-	res, reqErr := do(ctx, w.URL, http.MethodPost, headers, &buf)
+	res, reqErr := do(ctx, w.URL, http.MethodPost, headers, strings.NewReader(reqBody))
 	var reqHeaders string
 	for k, v := range headers {
 		reqHeaders += k + ": " + v[0] + "\n"


### PR DESCRIPTION
## Summary
- Fix Prometheus counters never `.Inc()` in HTTP + daemon (MUST-FIX)
- Validate newUsername in SetUsername (MUST-FIX)
- Move MaxBytesReader before any LFS body read (SHOULD-FIX)
- LFS lock delete: verify lock belongs to repo (SHOULD-FIX)
- Timing oracle: always attempt UserByAccessToken regardless of user-found/not-found (SHOULD-FIX)
- Webhook: pass strings.NewReader instead of exhausted buf to HTTP request (SHOULD-FIX)
- Remove deprecated net.Error.Temporary() (NIT)
- Fix Date/Expires headers to HTTP-date format (NIT)
- Cleanup ticker interval proportional to TTL (NIT)

Closes #839