### PR TITLE
fix: review-loop round 5 — SSRF via ssrf.ValidateURL, mixed DNS bypass, proxy IP, goroutine leak, nested tx

### DIFF
--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -2,14 +2,14 @@ package backend
 
 import (
 	"context"
-	"net/url"
 	"os/exec"
-	"strings"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/soft-serve/pkg/db"
 	"github.com/charmbracelet/soft-serve/pkg/db/models"
 	"github.com/charmbracelet/soft-serve/pkg/proto"
+	"github.com/charmbracelet/soft-serve/pkg/ssrf"
 )
 
 // AddPushMirror adds a push mirror to a repository.
@@ -49,28 +49,19 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 	const mirrorPushTimeout = 10 * time.Minute
 	const maxConcurrentPushes = 5
 	sem := make(chan struct{}, maxConcurrentPushes)
+	var wg sync.WaitGroup
 	for _, m := range mirrors {
 		if !m.Enabled {
 			continue
 		}
-		if u, err := url.Parse(m.RemoteURL); err == nil {
-			scheme := strings.ToLower(u.Scheme)
-			if scheme == "file" {
-				b.logger.Warn("push mirror: blocked file:// URL", "url", m.RemoteURL)
-				continue // skip this mirror
-			}
-			if scheme == "git" {
-				b.logger.Warn("push mirror: blocked git:// URL", "url", m.RemoteURL)
-				continue // skip this mirror
-			}
-			host := u.Hostname()
-			if host == "localhost" || host == "127.0.0.1" || host == "::1" {
-				b.logger.Warn("push mirror: blocked loopback address", "url", m.RemoteURL)
-				continue // skip this mirror
-			}
+		if err := ssrf.ValidateURL(m.RemoteURL); err != nil {
+			b.logger.Warn("push mirror: blocked URL", "url", m.RemoteURL, "err", err)
+			continue // skip this mirror
 		}
 		sem <- struct{}{} // acquire
+		wg.Add(1)
 		go func(m models.PushMirror) {
+			defer wg.Done()
 			defer func() { <-sem }() // release
 			mirrorCtx, cancel := context.WithTimeout(ctx, mirrorPushTimeout)
 			defer cancel()
@@ -83,4 +74,5 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 			}
 		}(m)
 	}
+	wg.Wait()
 }

--- a/pkg/backend/user.go
+++ b/pkg/backend/user.go
@@ -285,13 +285,37 @@ func (d *Backend) DeleteUser(ctx context.Context, username string) error {
 		return err
 	}
 
-	return d.db.TransactionContext(ctx, func(tx *db.Tx) error {
-		if err := d.store.DeleteUserByUsername(ctx, tx, username); err != nil {
+	// Collect the user's repo names and delete the user record in one transaction.
+	var repoNames []string
+	if err := d.db.TransactionContext(ctx, func(tx *db.Tx) error {
+		u, err := d.store.FindUserByUsername(ctx, tx, username)
+		if err != nil {
 			return db.WrapError(err)
 		}
 
-		return d.DeleteUserRepositories(ctx, username)
-	})
+		repos, err := d.store.GetUserRepos(ctx, tx, u.ID)
+		if err != nil {
+			return db.WrapError(err)
+		}
+
+		for _, r := range repos {
+			repoNames = append(repoNames, r.Name)
+		}
+
+		return db.WrapError(d.store.DeleteUserByUsername(ctx, tx, username))
+	}); err != nil {
+		return err
+	}
+
+	// Delete each repository outside the user-deletion transaction to avoid
+	// nested-transaction issues (especially on SQLite).
+	for _, name := range repoNames {
+		if err := d.DeleteRepository(ctx, name); err != nil {
+			d.logger.Error("error deleting user repo", "repo", name, "err", err)
+		}
+	}
+
+	return nil
 }
 
 // RemovePublicKey removes a public key from a user.

--- a/pkg/ssrf/ssrf.go
+++ b/pkg/ssrf/ssrf.go
@@ -46,7 +46,12 @@ func NewSecureClient() *http.Client {
 					if len(ips) == 0 {
 						return nil, fmt.Errorf("no IP addresses found for host: %s", host)
 					}
-					ip = ips[0] // Use the first resolved IP address
+					for _, candidate := range ips {
+						if isPrivateOrInternal(candidate) {
+							return nil, fmt.Errorf("%w", ErrPrivateIP)
+						}
+					}
+					ip = ips[0]
 				}
 				if isPrivateOrInternal(ip) {
 					return nil, fmt.Errorf("%w", ErrPrivateIP)

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -15,7 +15,6 @@ import (
 
 	"charm.land/log/v2"
 	"github.com/charmbracelet/soft-serve/pkg/access"
-	"github.com/charmbracelet/soft-serve/pkg/backend"
 	"github.com/charmbracelet/soft-serve/pkg/config"
 	"github.com/charmbracelet/soft-serve/pkg/db"
 	"github.com/charmbracelet/soft-serve/pkg/db/models"
@@ -308,23 +307,14 @@ func serviceLfsBasicUpload(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	oid := mux.Vars(r)["oid"]
 	cfg := config.FromContext(ctx)
-	be := backend.FromContext(ctx)
 	dbx := db.FromContext(ctx)
 	datastore := store.FromContext(ctx)
 	logger := log.FromContext(ctx).WithPrefix("http.lfs-basic")
 	repo := proto.RepositoryFromContext(ctx)
 	repoID := strconv.FormatInt(repo.ID(), 10)
 	strg := storage.NewLocalStorage(filepath.Join(cfg.DataPath, "lfs", repoID))
-	name := mux.Vars(r)["repo"]
 
 	defer r.Body.Close() //nolint: errcheck
-	repo, err := be.Repository(ctx, name)
-	if err != nil {
-		renderJSON(w, http.StatusNotFound, lfs.ErrorResponse{
-			Message: "repository not found",
-		})
-		return
-	}
 
 	// NOTE: Git LFS client will retry uploading the same object if there was a
 	// partial error, so we need to skip existing objects.

--- a/pkg/web/goget.go
+++ b/pkg/web/goget.go
@@ -94,7 +94,7 @@ func GoGetHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		goGetCounter.WithLabelValues(repo).Inc()
+		goGetCounter.WithLabelValues(sanitized).Inc()
 		return
 	}
 

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -2,7 +2,9 @@ package web
 
 import (
 	"context"
+	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"charm.land/log/v2"
@@ -13,10 +15,28 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// realClientIP extracts the real client IP from the request.
+// It uses the leftmost value of X-Forwarded-For when present,
+// otherwise falls back to RemoteAddr (with port stripped).
+func realClientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// The leftmost IP is the original client.
+		if idx := strings.IndexByte(xff, ','); idx != -1 {
+			return strings.TrimSpace(xff[:idx])
+		}
+		return strings.TrimSpace(xff)
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
 func newRateLimitMiddleware(limiter *ratelimit.IPLimiter) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if !limiter.Allow(r.RemoteAddr) {
+			if !limiter.Allow(realClientIP(r)) {
 				http.Error(w, "too many requests", http.StatusTooManyRequests)
 				return
 			}


### PR DESCRIPTION
## Summary
- Replace ad-hoc push mirror SSRF checks with ssrf.ValidateURL (MUST-FIX)
- Add WaitGroup drain to PushMirrors goroutines (SHOULD-FIX)
- SSRF DialContext: validate ALL resolved IPs, not just ips[0] (SHOULD-FIX)
- Rate limiter: extract real client IP from X-Forwarded-For (SHOULD-FIX)
- DeleteUser: collect repo names first, then delete repos outside outer tx (NIT)
- goGetCounter: use sanitized repo label (NIT)
- LFS upload: remove redundant repo DB lookup (NIT)

Closes #840