### PR TITLE
fix: review-loop round 6 — double counter, webhook scope, XFF bypass, LFS access, nil panic, SetPrivate webhook

### DIFF
--- a/pkg/backend/hooks.go
+++ b/pkg/backend/hooks.go
@@ -75,19 +75,10 @@ func (d *Backend) syncRepoMeta(ctx context.Context, repo string) {
 		return
 	}
 
-	// Only admins may change visibility — look up the pushing user
+	// Only admins may change visibility — look up the pushing user from context.
 	var isAdmin bool
-	if pubkey := os.Getenv("SOFT_SERVE_PUBLIC_KEY"); pubkey != "" {
-		pk, _, pkErr := sshutils.ParseAuthorizedKey(pubkey)
-		if pkErr == nil {
-			if u, uErr := d.UserByPublicKey(ctx, pk); uErr == nil {
-				isAdmin = u.IsAdmin()
-			}
-		}
-	} else if username := os.Getenv("SOFT_SERVE_USERNAME"); username != "" {
-		if u, uErr := d.User(ctx, username); uErr == nil {
-			isAdmin = u.IsAdmin()
-		}
+	if u := proto.UserFromContext(ctx); u != nil {
+		isAdmin = u.IsAdmin()
 	}
 
 	if meta.Description != "" {

--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -631,6 +631,13 @@ func (d *Backend) SetPrivate(ctx context.Context, name string, private bool) err
 	name = utils.SanitizeRepo(name)
 	rp := filepath.Join(d.repoPath(name))
 
+	// Capture the old visibility before updating.
+	oldRepo, err := d.Repository(ctx, name)
+	if err != nil {
+		return err
+	}
+	oldPrivate := oldRepo.IsPrivate()
+
 	// Delete cache
 	d.cache.Delete(name)
 
@@ -663,7 +670,7 @@ func (d *Backend) SetPrivate(ctx context.Context, name string, private bool) err
 		return err
 	}
 
-	if repo.IsPrivate() != !private {
+	if oldPrivate != private {
 		wh, err := webhook.NewRepositoryEvent(ctx, user, repo, webhook.RepositoryEventActionVisibilityChange)
 		if err != nil {
 			return err

--- a/pkg/backend/user.go
+++ b/pkg/backend/user.go
@@ -309,10 +309,15 @@ func (d *Backend) DeleteUser(ctx context.Context, username string) error {
 
 	// Delete each repository outside the user-deletion transaction to avoid
 	// nested-transaction issues (especially on SQLite).
+	var errs []error
 	for _, name := range repoNames {
 		if err := d.DeleteRepository(ctx, name); err != nil {
 			d.logger.Error("error deleting user repo", "repo", name, "err", err)
+			errs = append(errs, err)
 		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
 	}
 
 	return nil

--- a/pkg/backend/webhooks.go
+++ b/pkg/backend/webhooks.go
@@ -286,12 +286,19 @@ func (b *Backend) RedeliverWebhookDelivery(ctx context.Context, repo proto.Repos
 }
 
 // WebhookDelivery returns a webhook delivery.
-func (b *Backend) WebhookDelivery(ctx context.Context, webhookID int64, id uuid.UUID) (webhook.Delivery, error) {
+// It verifies that the webhook belongs to the given repository before
+// returning the delivery to prevent cross-repo information leakage.
+func (b *Backend) WebhookDelivery(ctx context.Context, repo proto.Repository, webhookID int64, id uuid.UUID) (webhook.Delivery, error) {
 	dbx := db.FromContext(ctx)
 	datastore := store.FromContext(ctx)
 
 	var delivery webhook.Delivery
 	if err := dbx.TransactionContext(ctx, func(tx *db.Tx) error {
+		// Verify webhook belongs to this repository before fetching delivery.
+		if _, err := datastore.GetWebhookByID(ctx, tx, repo.ID(), webhookID); err != nil {
+			return db.WrapError(err)
+		}
+
 		d, err := datastore.GetWebhookDeliveryByID(ctx, tx, webhookID, id)
 		if err != nil {
 			return db.WrapError(err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -113,6 +113,11 @@ type HTTPConfig struct {
 	// When true, both /<name> and /<name>.git are accepted.
 	// Default is false for backward compatibility.
 	StripGitSuffix bool `env:"STRIP_GIT_SUFFIX" yaml:"strip_git_suffix"`
+
+	// TrustProxyHeaders controls whether the X-Forwarded-For header is trusted
+	// for client IP resolution. Only enable this when the server sits behind a
+	// trusted reverse proxy. Default is false.
+	TrustProxyHeaders bool `env:"SOFT_SERVE_HTTP_TRUST_PROXY_HEADERS" yaml:"trust_proxy_headers"`
 }
 
 // StatsConfig is the configuration for the stats server.

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -115,6 +115,10 @@ http:
   # Both /<name> and /<name>.git will be accepted.
   # strip_git_suffix: false
 
+  # When true, the X-Forwarded-For header is trusted for client IP resolution.
+  # Only enable this when the server sits behind a trusted reverse proxy.
+  # trust_proxy_headers: false
+
   # The cross-origin request security options
   cors:
     # The allowed cross-origin headers

--- a/pkg/ssh/cmd/git.go
+++ b/pkg/ssh/cmd/git.go
@@ -263,8 +263,6 @@ func gitRunE(cmd *cobra.Command, args []string) error {
 			return git.ErrSystemMalfunction
 		}
 
-		receivePackCounter.WithLabelValues(name).Inc()
-
 		return nil
 	case git.UploadPackService, git.UploadArchiveService:
 		if accessLevel < access.ReadOnlyAccess {

--- a/pkg/ssh/cmd/webhooks.go
+++ b/pkg/ssh/cmd/webhooks.go
@@ -353,6 +353,11 @@ func webhookDeliveriesGetCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			be := backend.FromContext(ctx)
+			repo, err := be.Repository(ctx, args[0])
+			if err != nil {
+				return err
+			}
+
 			id, err := strconv.ParseInt(args[1], 10, 64)
 			if err != nil {
 				return fmt.Errorf("invalid webhook ID: %w", err)
@@ -363,7 +368,7 @@ func webhookDeliveriesGetCommand() *cobra.Command {
 				return fmt.Errorf("invalid delivery ID: %w", err)
 			}
 
-			del, err := be.WebhookDelivery(ctx, id, delID)
+			del, err := be.WebhookDelivery(ctx, repo, id, delID)
 			if err != nil {
 				return err
 			}

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -363,15 +363,22 @@ func withAccess(next http.Handler) http.HandlerFunc {
 			switch {
 			case strings.HasPrefix(file, "info/lfs/locks"):
 				switch {
-				case strings.HasSuffix(file, "lfs/locks"), strings.HasSuffix(file, "/unlock") && r.Method == http.MethodPost:
-					// Create lock, list locks, and delete lock require write access
-					fallthrough
-				case strings.HasSuffix(file, "lfs/locks/verify"):
-					// Locks verify requires write access
+				case strings.HasSuffix(file, "lfs/locks") && r.Method == http.MethodPost,
+					strings.HasSuffix(file, "/unlock") && r.Method == http.MethodPost,
+					strings.HasSuffix(file, "lfs/locks/verify"):
+					// Create lock, delete lock, and verify require write access.
 					// https://github.com/git-lfs/git-lfs/blob/main/docs/api/locking.md#unauthorized-response-2
 					if accessLevel < access.ReadWriteAccess {
 						renderJSON(w, http.StatusForbidden, lfs.ErrorResponse{
 							Message: "write access required",
+						})
+						return
+					}
+				case strings.HasSuffix(file, "lfs/locks") && r.Method == http.MethodGet:
+					// List locks only requires read access.
+					if accessLevel < access.ReadOnlyAccess {
+						renderJSON(w, http.StatusForbidden, lfs.ErrorResponse{
+							Message: "read access required",
 						})
 						return
 					}

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -244,6 +244,10 @@ func serviceLfsBasicDownload(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	oid := mux.Vars(r)["oid"]
 	repo := proto.RepositoryFromContext(ctx)
+	if repo == nil {
+		renderStatus(http.StatusNotFound)(w, r)
+		return
+	}
 	cfg := config.FromContext(ctx)
 	logger := log.FromContext(ctx).WithPrefix("http.lfs-basic")
 	datastore := store.FromContext(ctx)

--- a/pkg/web/logging.go
+++ b/pkg/web/logging.go
@@ -22,7 +22,6 @@ var (
 	_ http.ResponseWriter = (*logWriter)(nil)
 	_ http.Flusher        = (*logWriter)(nil)
 	_ http.Hijacker       = (*logWriter)(nil)
-	_ http.CloseNotifier  = (*logWriter)(nil)
 )
 
 // Write implements http.ResponseWriter.
@@ -49,14 +48,6 @@ func (r *logWriter) Flush() {
 	if f, ok := r.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
-}
-
-// CloseNotify implements http.CloseNotifier.
-func (r *logWriter) CloseNotify() <-chan bool {
-	if cn, ok := r.ResponseWriter.(http.CloseNotifier); ok {
-		return cn.CloseNotify()
-	}
-	return nil
 }
 
 // Hijack implements http.Hijacker.

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -16,15 +16,17 @@ import (
 )
 
 // realClientIP extracts the real client IP from the request.
-// It uses the leftmost value of X-Forwarded-For when present,
-// otherwise falls back to RemoteAddr (with port stripped).
-func realClientIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// The leftmost IP is the original client.
-		if idx := strings.IndexByte(xff, ','); idx != -1 {
-			return strings.TrimSpace(xff[:idx])
+// When trustProxyHeaders is true it uses the leftmost value of
+// X-Forwarded-For; otherwise it falls back to RemoteAddr (with port stripped).
+func realClientIP(r *http.Request, trustProxyHeaders bool) string {
+	if trustProxyHeaders {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			// The leftmost IP is the original client.
+			if idx := strings.IndexByte(xff, ','); idx != -1 {
+				return strings.TrimSpace(xff[:idx])
+			}
+			return strings.TrimSpace(xff)
 		}
-		return strings.TrimSpace(xff)
 	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
@@ -33,10 +35,10 @@ func realClientIP(r *http.Request) string {
 	return host
 }
 
-func newRateLimitMiddleware(limiter *ratelimit.IPLimiter) func(http.Handler) http.Handler {
+func newRateLimitMiddleware(limiter *ratelimit.IPLimiter, trustProxyHeaders bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if !limiter.Allow(realClientIP(r)) {
+			if !limiter.Allow(realClientIP(r, trustProxyHeaders)) {
 				http.Error(w, "too many requests", http.StatusTooManyRequests)
 				return
 			}
@@ -80,7 +82,7 @@ func NewRouter(ctx context.Context) http.Handler {
 	h = handlers.CompressHandler(h)
 	h = handlers.RecoveryHandler()(h)
 	h = securityHeadersMiddleware(h)
-	h = newRateLimitMiddleware(httpLimiter)(h)
+	h = newRateLimitMiddleware(httpLimiter, cfg.HTTP.TrustProxyHeaders)(h)
 
 	h = handlers.CORS(handlers.AllowedHeaders(cfg.HTTP.CORS.AllowedHeaders),
 		handlers.AllowedOrigins(cfg.HTTP.CORS.AllowedOrigins),


### PR DESCRIPTION
## Summary
- Remove duplicate receivePackCounter increment (MUST-FIX)
- WebhookDelivery: add repo-scope guard before fetching delivery (MUST-FIX)
- XFF only trusted when TrustProxyHeaders config is true (MUST-FIX)
- LFS GET locks: require ReadOnlyAccess, not ReadWriteAccess (SHOULD-FIX)
- serviceLfsBasicDownload: nil repo guard (SHOULD-FIX)
- DeleteUser: collect and return repo-deletion errors (SHOULD-FIX)
- SetPrivate: fix inverted visibility webhook condition (NIT)
- Remove deprecated CloseNotifier from logWriter (NIT)
- syncRepoMeta: use proto.UserFromContext instead of env vars (SHOULD-FIX)

Closes #841