### PR TITLE
fix: review-loop round 7 — GIT_PROTOCOL SSH sanitization, LFS scanner stderr, basic download DB sync

### DIFF
--- a/pkg/lfs/scanner.go
+++ b/pkg/lfs/scanner.go
@@ -108,7 +108,6 @@ func catFileBatch(ctx context.Context, shasToBatchReader *io.PipeReader, catFile
 	defer catFileBatchWriter.Close() //nolint: errcheck
 
 	stderr := new(bytes.Buffer)
-	var errbuf strings.Builder
 	if err := gitm.NewCommandWithContext(ctx, "cat-file", "--batch").
 		WithTimeout(-1).
 		RunInDirWithOptions(basePath, gitm.RunInDirOptions{
@@ -116,7 +115,7 @@ func catFileBatch(ctx context.Context, shasToBatchReader *io.PipeReader, catFile
 			Stdin:  shasToBatchReader,
 			Stderr: stderr,
 		}); err != nil {
-		_ = shasToBatchReader.CloseWithError(fmt.Errorf("git rev-list [%s]: %w - %s", basePath, err, errbuf.String()))
+		_ = shasToBatchReader.CloseWithError(fmt.Errorf("git rev-list [%s]: %w - %s", basePath, err, stderr.String()))
 	}
 }
 
@@ -158,7 +157,6 @@ func catFileBatchCheck(ctx context.Context, shasToCheckReader *io.PipeReader, ca
 	defer catFileCheckWriter.Close() //nolint: errcheck
 
 	stderr := new(bytes.Buffer)
-	var errbuf strings.Builder
 	if err := gitm.NewCommandWithContext(ctx, "cat-file", "--batch-check").
 		WithTimeout(-1).
 		RunInDirWithOptions(basePath, gitm.RunInDirOptions{
@@ -166,7 +164,7 @@ func catFileBatchCheck(ctx context.Context, shasToCheckReader *io.PipeReader, ca
 			Stdin:  shasToCheckReader,
 			Stderr: stderr,
 		}); err != nil {
-		_ = shasToCheckReader.CloseWithError(fmt.Errorf("git rev-list [%s]: %w - %s", basePath, err, errbuf.String()))
+		_ = shasToCheckReader.CloseWithError(fmt.Errorf("git rev-list [%s]: %w - %s", basePath, err, stderr.String()))
 	}
 }
 
@@ -204,13 +202,12 @@ func revListAllObjects(ctx context.Context, revListWriter *io.PipeWriter, wg *sy
 	defer revListWriter.Close() //nolint: errcheck
 
 	stderr := new(bytes.Buffer)
-	var errbuf strings.Builder
 	if err := gitm.NewCommandWithContext(ctx, "rev-list", "--objects", "--all").
 		WithTimeout(-1).
 		RunInDirWithOptions(basePath, gitm.RunInDirOptions{
 			Stdout: revListWriter,
 			Stderr: stderr,
 		}); err != nil {
-		errChan <- fmt.Errorf("git rev-list [%s]: %w - %s", basePath, err, errbuf.String())
+		errChan <- fmt.Errorf("git rev-list [%s]: %w - %s", basePath, err, stderr.String())
 	}
 }

--- a/pkg/ssh/cmd/git.go
+++ b/pkg/ssh/cmd/git.go
@@ -210,7 +210,18 @@ func gitRunE(cmd *cobra.Command, args []string) error {
 	if sess := sshutils.SessionFromContext(ctx); sess != nil {
 		for _, env := range sess.Environ() {
 			if strings.HasPrefix(env, "GIT_PROTOCOL=") {
-				envs = append(envs, env)
+				val := env[len("GIT_PROTOCOL="):]
+				// Sanitize: reject any control characters to prevent env var injection.
+				clean := true
+				for _, c := range val {
+					if c < 0x20 || c == 0x7f {
+						clean = false
+						break
+					}
+				}
+				if clean {
+					envs = append(envs, env)
+				}
 				break
 			}
 		}

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -280,6 +280,14 @@ func serviceLfsBasicDownload(w http.ResponseWriter, r *http.Request) {
 	} else {
 		if stat, err := strg.Stat(path.Join("objects", pointer.RelativePath())); err == nil {
 			size = stat.Size()
+			// Object exists on disk but is not in the database; register it now.
+			if err := datastore.CreateLFSObject(ctx, dbx, repo.ID(), oid, size); err != nil {
+				logger.Error("error creating lfs object in datastore", "oid", oid, "repo", repo.Name(), "err", err)
+				renderJSON(w, http.StatusInternalServerError, lfs.ErrorResponse{
+					Message: "internal server error",
+				})
+				return
+			}
 		}
 	}
 	w.Header().Set("Content-Type", "application/octet-stream")
@@ -425,6 +433,10 @@ func serviceLfsBasicVerify(w http.ResponseWriter, r *http.Request) {
 			renderJSON(w, http.StatusOK, map[string]string{"message": "verified"})
 			return
 		}
+		renderJSON(w, http.StatusUnprocessableEntity, struct {
+			Message string `json:"message"`
+		}{"size mismatch"})
+		return
 	} else if errors.Is(err, fs.ErrNotExist) {
 		logger.Error("file not found", "oid", pointer.Oid)
 		renderJSON(w, http.StatusNotFound, lfs.ErrorResponse{


### PR DESCRIPTION
## Summary
- Sanitize GIT_PROTOCOL on SSH path (strip control chars) (SHOULD-FIX)
- LFS scanner: use stderr.String() instead of errbuf.String() in error messages (SHOULD-FIX)
- serviceLfsBasicDownload: insert missing DB record when file exists on disk (SHOULD-FIX)
- serviceLfsBasicVerify: add terminal response for size-mismatch path (NIT)
- Remove unused errbuf variables from scanner (NIT)

Closes #842