### PR TITLE
fix: review-loop round 8 — ImportRepository SSRF, task Manager TOCTOU, workqueue WaitGroup, description perms

### DIFF
--- a/pkg/backend/hooks.go
+++ b/pkg/backend/hooks.go
@@ -33,7 +33,7 @@ func (d *Backend) PostReceive(_ context.Context, _ io.Writer, _ io.Writer, repo 
 	// Sync .soft-serve.yaml metadata asynchronously so the push
 	// response is not blocked by DB writes or git tree reads.
 	go func() {
-		syncCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		syncCtx, cancel := context.WithTimeout(d.ctx, 30*time.Second)
 		defer cancel()
 		d.syncRepoMeta(syncCtx, repo)
 	}()

--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -19,6 +19,7 @@ import (
 	"github.com/charmbracelet/soft-serve/pkg/hooks"
 	"github.com/charmbracelet/soft-serve/pkg/lfs"
 	"github.com/charmbracelet/soft-serve/pkg/proto"
+	"github.com/charmbracelet/soft-serve/pkg/ssrf"
 	"github.com/charmbracelet/soft-serve/pkg/storage"
 	"github.com/charmbracelet/soft-serve/pkg/task"
 	"github.com/charmbracelet/soft-serve/pkg/utils"
@@ -29,6 +30,12 @@ func validateImportRemote(remote string) error {
 	endpoint, err := lfs.NewEndpoint(remote)
 	if err != nil || endpoint.Host == "" {
 		return proto.ErrInvalidRemote
+	}
+
+	if endpoint.Scheme == "http" || endpoint.Scheme == "https" {
+		if err := ssrf.ValidateURL(remote); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -95,7 +102,7 @@ func (d *Backend) CreateRepository(ctx context.Context, name string, user proto.
 			}
 		}
 
-		if err := os.WriteFile(filepath.Join(rp, "description"), []byte(opts.Description), fs.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(rp, "description"), []byte(opts.Description), 0o644); err != nil {
 			d.logger.Error("failed to write description", "repo", name, "err", err)
 			return err
 		}
@@ -285,9 +292,6 @@ func (d *Backend) DeleteRepository(ctx context.Context, name string) error {
 	}
 
 	if err := d.db.TransactionContext(ctx, func(tx *db.Tx) error {
-		// Delete repo from cache
-		defer d.cache.Delete(name)
-
 		repom, dberr := d.store.GetRepoByName(ctx, tx, name)
 		_, ferr := os.Stat(rp)
 		if dberr != nil && ferr != nil {
@@ -332,6 +336,8 @@ func (d *Backend) DeleteRepository(ctx context.Context, name string) error {
 
 		return db.WrapError(err)
 	}
+
+	d.cache.Delete(name)
 
 	return webhook.SendEvent(ctx, wh)
 }
@@ -615,7 +621,7 @@ func (d *Backend) SetDescription(ctx context.Context, name string, desc string) 
 	d.cache.Delete(name)
 
 	return d.db.TransactionContext(ctx, func(tx *db.Tx) error {
-		if err := os.WriteFile(filepath.Join(rp, "description"), []byte(desc), fs.ModePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(rp, "description"), []byte(desc), 0o644); err != nil {
 			d.logger.Error("failed to write description", "repo", name, "err", err)
 			return err
 		}

--- a/pkg/backend/user.go
+++ b/pkg/backend/user.go
@@ -280,6 +280,7 @@ func (d *Backend) CreateUser(ctx context.Context, username string, opts proto.Us
 //
 // It implements backend.Backend.
 func (d *Backend) DeleteUser(ctx context.Context, username string) error {
+	username = utils.Sanitize(username)
 	username = strings.ToLower(username)
 	if err := utils.ValidateUsername(username); err != nil {
 		return err
@@ -378,6 +379,7 @@ func (d *Backend) SetUsername(ctx context.Context, username string, newUsername 
 //
 // It implements backend.Backend.
 func (d *Backend) SetAdmin(ctx context.Context, username string, admin bool) error {
+	username = utils.Sanitize(username)
 	username = strings.ToLower(username)
 	if err := utils.ValidateUsername(username); err != nil {
 		return err

--- a/pkg/sync/workqueue.go
+++ b/pkg/sync/workqueue.go
@@ -50,6 +50,8 @@ func NewWorkPool(ctx context.Context, workers int, opts ...WorkPoolOption) *Work
 
 // Run starts the workers and waits for them to finish.
 func (wq *WorkPool) Run() {
+	var wg sync.WaitGroup
+
 	wq.work.Range(func(key, value any) bool {
 		id := key.(string)
 		fn := value.(func())
@@ -58,7 +60,9 @@ func (wq *WorkPool) Run() {
 			return false
 		}
 
+		wg.Add(1)
 		go func(id string, fn func()) {
+			defer wg.Done()
 			defer wq.sem.Release(1)
 			fn()
 			wq.work.Delete(id)
@@ -67,9 +71,7 @@ func (wq *WorkPool) Run() {
 		return true
 	})
 
-	if err := wq.sem.Acquire(wq.ctx, int64(wq.workers)); err != nil {
-		wq.logf("workpool: %v", err)
-	}
+	wg.Wait()
 }
 
 // Add adds a new job to the pool.

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -42,17 +42,16 @@ func NewManager(ctx context.Context) *Manager {
 // Add adds a task to the manager.
 // If the process already exists, it is a no-op.
 func (m *Manager) Add(id string, fn func(context.Context) error) {
-	if m.Exists(id) {
-		return
-	}
-
 	ctx, cancel := context.WithCancel(m.ctx)
-	m.m.Store(id, &Task{
+	t := &Task{
 		id:     id,
 		fn:     fn,
 		ctx:    ctx,
 		cancel: cancel,
-	})
+	}
+	if _, loaded := m.m.LoadOrStore(id, t); loaded {
+		cancel()
+	}
 }
 
 // Stop stops the task and removes it from the manager.

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -64,7 +64,8 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 		if len(logUsername) > 20 {
 			logUsername = logUsername[:20] + "…"
 		}
-		logger.Error("invalid password or token", "username", logUsername, "err", err)
+		logger.Debug("invalid password or token detail", "username", logUsername, "err", err)
+		logger.Error("invalid credentials", "username", logUsername)
 		return nil, errInvalidPassword
 	} else if username != "" {
 		// Try to authenticate using access token as the username

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -676,6 +676,10 @@ func sendFile(contentType string, w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
+	if rel, err := filepath.Rel(dir, reqFile); err != nil || strings.HasPrefix(rel, "..") {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
 
 	f, err := os.Stat(reqFile)
 	if os.IsNotExist(err) {

--- a/pkg/web/http.go
+++ b/pkg/web/http.go
@@ -31,9 +31,11 @@ func NewHTTPServer(ctx context.Context) (*HTTPServer, error) {
 			Addr:              cfg.HTTP.ListenAddr,
 			Handler:           NewRouter(ctx),
 			ReadHeaderTimeout: time.Second * 10,
-			// WriteTimeout is intentionally not set here: git pack-objects streams can
-			// take hours for large repositories, and a fixed deadline would kill legitimate
-			// large clones/pushes. Connection idle timeouts are enforced by IdleTimeout.
+			// WriteTimeout and ReadTimeout are intentionally not set: git pack-objects
+			// streams can take hours for large repositories, and a fixed deadline would
+			// kill legitimate large clones/pushes. ReadHeaderTimeout is set instead to
+			// guard against slow-header attacks without breaking long-running git transfers.
+			// Connection idle timeouts are enforced by IdleTimeout.
 			IdleTimeout: time.Second * 10,
 			MaxHeaderBytes:    http.DefaultMaxHeaderBytes,
 			ErrorLog:          logger.StandardLog(log.StandardLogOptions{ForceLevel: log.ErrorLevel}),


### PR DESCRIPTION
## Summary
- ImportRepository: call ssrf.ValidateURL for http/https remotes (MUST-FIX)
- task.Manager.Add: use LoadOrStore for atomic check+store (MUST-FIX)
- Description file: 0o644 instead of 0777 (SHOULD-FIX)
- auth: redact raw DB error from error log (SHOULD-FIX)
- WorkPool.Run: use WaitGroup instead of broken semaphore drain (SHOULD-FIX)
- PostReceive: use d.ctx instead of context.Background() (SHOULD-FIX)
- DeleteRepository: cache.Delete only on successful transaction (SHOULD-FIX)
- user: apply utils.Sanitize consistently in DeleteUser/SetAdmin (NIT)
- server.go: improve timeout comment (NIT)
- git.go: add filepath.Rel double-check to path traversal guard (NIT)

Closes #843