### PR TITLE
fix: review-loop round 9 — LFS batch MaxBytesReader, SSH mirror SSRF bypass, CSP, auth log, webhook headers

### DIFF
--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"net/url"
 	"os/exec"
 	"sync"
 	"time"
@@ -54,9 +55,12 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 		if !m.Enabled {
 			continue
 		}
-		if err := ssrf.ValidateURL(m.RemoteURL); err != nil {
-			b.logger.Warn("push mirror: blocked URL", "url", m.RemoteURL, "err", err)
-			continue // skip this mirror
+		u, err := url.Parse(m.RemoteURL)
+		if err == nil && (u.Scheme == "http" || u.Scheme == "https") {
+			if ssrfErr := ssrf.ValidateURL(m.RemoteURL); ssrfErr != nil {
+				b.logger.Warn("push mirror: SSRF check failed", "remote", m.RemoteURL, "err", ssrfErr)
+				continue
+			}
 		}
 		sem <- struct{}{} // acquire
 		wg.Add(1)

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -64,8 +64,7 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 		if len(logUsername) > 20 {
 			logUsername = logUsername[:20] + "…"
 		}
-		logger.Debug("invalid password or token detail", "username", logUsername, "err", err)
-		logger.Error("invalid credentials", "username", logUsername)
+		logger.Debug("invalid credentials", "username", logUsername, "err", err)
 		return nil, errInvalidPassword
 	} else if username != "" {
 		// Try to authenticate using access token as the username

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -39,6 +39,7 @@ func serviceLfsBatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	var batchRequest lfs.BatchRequest
 	defer r.Body.Close() //nolint: errcheck
 	if err := json.NewDecoder(r.Body).Decode(&batchRequest); err != nil {
@@ -377,6 +378,7 @@ func serviceLfsBasicVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	var pointer lfs.Pointer
 	ctx := r.Context()
 	logger := log.FromContext(ctx).WithPrefix("http.lfs-basic")
@@ -470,6 +472,7 @@ func serviceLfsLocksCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	ctx := r.Context()
 	logger := log.FromContext(ctx).WithPrefix("http.lfs-locks")
 
@@ -765,6 +768,7 @@ func serviceLfsLocksVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	var req lfs.LockVerifyRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		logger.Error("error decoding request", "err", err)
@@ -871,6 +875,7 @@ func serviceLfsLocksDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	var req lfs.LockDeleteRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		logger.Error("error decoding request", "err", err)

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -53,7 +53,7 @@ func securityHeadersMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
-		w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'")
+		w.Header().Set("Content-Security-Policy", "default-src 'none'")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -102,7 +102,7 @@ func SendWebhook(ctx context.Context, w models.Webhook, event Event, payload int
 	res, reqErr := do(ctx, w.URL, http.MethodPost, headers, strings.NewReader(reqBody))
 	var reqHeaders string
 	for k, v := range headers {
-		reqHeaders += k + ": " + v[0] + "\n"
+		reqHeaders += k + ": " + strings.Join(v, ", ") + "\n"
 	}
 
 	resStatus := 0


### PR DESCRIPTION
## Summary
- LFS JSON handlers: add MaxBytesReader(1MB) before json.Decode (SHOULD-FIX)
- Push mirror: only apply ssrf.ValidateURL for http/https, skip ssh:// (SHOULD-FIX)
- CSP: remove unused style-src 'unsafe-inline' (NIT)
- auth: consolidate double log entry for failed credentials (NIT)
- webhook: record all values for multi-value headers (NIT)

Closes #844