### PR TITLE
fix: review-loop round 10 — empty token entropy, limiter leak, push env, PostReceive user ctx, header sort

### DIFF
--- a/pkg/backend/access_token.go
+++ b/pkg/backend/access_token.go
@@ -12,7 +12,13 @@ import (
 
 // CreateAccessToken creates an access token for user.
 func (b *Backend) CreateAccessToken(ctx context.Context, user proto.User, name string, expiresAt time.Time) (string, error) {
-	token := GenerateToken()
+	token, err := GenerateToken()
+	if err != nil {
+		return "", err
+	}
+	if token == "" {
+		return "", errors.New("generated token is empty")
+	}
 	tokenHash := HashToken(token)
 	name = utils.Sanitize(name)
 

--- a/pkg/backend/auth.go
+++ b/pkg/backend/auth.go
@@ -4,8 +4,8 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 
-	"charm.land/log/v2"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -26,14 +26,13 @@ func VerifyPassword(password, hash string) bool {
 }
 
 // GenerateToken returns a random unique token.
-func GenerateToken() string {
+func GenerateToken() (string, error) {
 	buf := make([]byte, 20)
 	if _, err := rand.Read(buf); err != nil {
-		log.Error("unable to generate access token")
-		return ""
+		return "", fmt.Errorf("generate access token: %w", err)
 	}
 
-	return "ss_" + hex.EncodeToString(buf)
+	return "ss_" + hex.EncodeToString(buf), nil
 }
 
 // HashToken hashes the token using sha256.

--- a/pkg/backend/auth_test.go
+++ b/pkg/backend/auth_test.go
@@ -23,14 +23,20 @@ func TestVerifyPassword(t *testing.T) {
 }
 
 func TestGenerateToken(t *testing.T) {
-	token := GenerateToken()
+	token, err := GenerateToken()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if token == "" {
 		t.Fatal("token is empty")
 	}
 }
 
 func TestHashToken(t *testing.T) {
-	token := GenerateToken()
+	token, err := GenerateToken()
+	if err != nil {
+		t.Fatal(err)
+	}
 	hash := HashToken(token)
 	if hash == "" {
 		t.Fatal("hash is empty")

--- a/pkg/backend/hooks.go
+++ b/pkg/backend/hooks.go
@@ -27,21 +27,28 @@ type repoMetaConfig struct {
 // PostReceive is called by the git post-receive hook. It implements Hooks.
 // Metadata sync (.soft-serve.yaml) is performed asynchronously so the push
 // response is not blocked by DB writes or git tree reads.
-func (d *Backend) PostReceive(_ context.Context, _ io.Writer, _ io.Writer, repo string, args []hooks.HookArg) {
+func (d *Backend) PostReceive(ctx context.Context, _ io.Writer, _ io.Writer, repo string, args []hooks.HookArg) {
 	d.logger.Debug("post-receive hook called", "repo", repo, "args", args)
+
+	// Capture the pushing user before the goroutine is launched so that the
+	// caller's context (which may be cancelled after the push completes) does
+	// not need to remain valid inside the goroutine.
+	user := proto.UserFromContext(ctx)
 
 	// Sync .soft-serve.yaml metadata asynchronously so the push
 	// response is not blocked by DB writes or git tree reads.
 	go func() {
 		syncCtx, cancel := context.WithTimeout(d.ctx, 30*time.Second)
 		defer cancel()
-		d.syncRepoMeta(syncCtx, repo)
+		d.syncRepoMeta(syncCtx, repo, user)
 	}()
 }
 
 // syncRepoMeta reads .soft-serve.yaml from HEAD and applies non-zero fields
 // to the repository backend. Private and hidden require admin access.
-func (d *Backend) syncRepoMeta(ctx context.Context, repo string) {
+// user is the pushing user captured from the caller's context before the
+// goroutine was launched.
+func (d *Backend) syncRepoMeta(ctx context.Context, repo string, user proto.User) {
 	r, err := d.Repository(ctx, repo)
 	if err != nil {
 		d.logger.Warn("post-receive: failed to find repository", "repo", repo, "err", err)
@@ -75,10 +82,12 @@ func (d *Backend) syncRepoMeta(ctx context.Context, repo string) {
 		return
 	}
 
-	// Only admins may change visibility — look up the pushing user from context.
+	// Only admins may change visibility. Use the user captured from the
+	// caller's context rather than looking it up from d.ctx, which would
+	// return nil because d.ctx has no user attached.
 	var isAdmin bool
-	if u := proto.UserFromContext(ctx); u != nil {
-		isAdmin = u.IsAdmin()
+	if user != nil {
+		isAdmin = user.IsAdmin()
 	}
 
 	if meta.Description != "" {

--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"context"
 	"net/url"
+	"os"
 	"os/exec"
 	"sync"
 	"time"
@@ -71,6 +72,13 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 			defer cancel()
 			cmd := exec.CommandContext(mirrorCtx, "git", "push", "--mirror", m.RemoteURL)
 			cmd.Dir = repoPath
+			cmd.Env = []string{
+				"HOME=" + os.Getenv("HOME"),
+				"PATH=" + os.Getenv("PATH"),
+			}
+			if sshCmd := os.Getenv("GIT_SSH_COMMAND"); sshCmd != "" {
+				cmd.Env = append(cmd.Env, "GIT_SSH_COMMAND="+sshCmd)
+			}
 			if out, err := cmd.CombinedOutput(); err != nil {
 				b.logger.Warn("push-mirror: push failed", "repo", repo.Name(), "mirror", m.Name, "err", err, "output", string(out))
 			} else {

--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -131,7 +131,7 @@ func (d *Backend) CreateRepository(ctx context.Context, name string, user proto.
 
 // ImportRepository imports a repository from remote.
 // XXX: This a expensive operation and should be run in a goroutine.
-func (d *Backend) ImportRepository(_ context.Context, name string, user proto.User, remote string, opts proto.RepositoryOptions) (proto.Repository, error) {
+func (d *Backend) ImportRepository(ctx context.Context, name string, user proto.User, remote string, opts proto.RepositoryOptions) (proto.Repository, error) {
 	name = utils.SanitizeRepo(name)
 	if err := utils.ValidateRepo(name); err != nil {
 		return nil, err
@@ -153,6 +153,10 @@ func (d *Backend) ImportRepository(_ context.Context, name string, user proto.Us
 		return nil, task.ErrAlreadyStarted
 	}
 
+	// Note: there is a TOCTOU between the Exists check, filesystem stat, and
+	// manager.Add. The task manager's LoadOrStore provides atomic dedup for
+	// concurrent callers, so this is safe for correctness; the stat check is
+	// advisory only.
 	if _, err := os.Stat(rp); err == nil || os.IsExist(err) {
 		return nil, proto.ErrRepoExist
 	}
@@ -160,8 +164,12 @@ func (d *Backend) ImportRepository(_ context.Context, name string, user proto.Us
 	done := make(chan error, 1)
 	repoc := make(chan proto.Repository, 1)
 	d.logger.Info("importing repository", "name", name, "remote", remote, "path", rp)
-	d.manager.Add(tid, func(ctx context.Context) (err error) {
-		ctx = proto.WithUserContext(ctx, user)
+	// Use context.WithoutCancel so the import task outlives the HTTP request
+	// that initiated it, but still inherits values (e.g. logger, config) from
+	// the caller's context.
+	importCtx := context.WithoutCancel(ctx)
+	d.manager.Add(tid, func(_ context.Context) (err error) {
+		ctx := proto.WithUserContext(importCtx, user)
 
 		copts := git.CloneOptions{
 			Bare:   true,

--- a/pkg/backend/user.go
+++ b/pkg/backend/user.go
@@ -308,6 +308,9 @@ func (d *Backend) DeleteUser(ctx context.Context, username string) error {
 		return err
 	}
 
+	// The user record is deleted in one transaction; repo deletions happen
+	// outside that transaction. There is a brief window where repos exist
+	// without an owner. This is accepted as a structural limitation.
 	// Delete each repository outside the user-deletion transaction to avoid
 	// nested-transaction issues (especially on SQLite).
 	var errs []error

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -45,6 +45,8 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 		if err != nil {
 			// Run a dummy bcrypt comparison to prevent username enumeration via timing.
 			_ = bcrypt.CompareHashAndPassword([]byte(dummyHash), []byte(password))
+			// Timing equalization is best-effort. The DB query has variable latency,
+			// so this is not a constant-time guarantee but reduces the timing gap.
 			// Also attempt token lookup so the not-found and wrong-password paths
 			// do the same amount of work.
 			_, _ = be.UserByAccessToken(ctx, password)

--- a/pkg/web/http.go
+++ b/pkg/web/http.go
@@ -17,19 +17,22 @@ type HTTPServer struct {
 	ctx context.Context
 	cfg *config.Config
 
-	Server *http.Server
+	Server      *http.Server
+	httpLimiter interface{ Close() }
 }
 
 // NewHTTPServer creates a new HTTP server.
 func NewHTTPServer(ctx context.Context) (*HTTPServer, error) {
 	cfg := config.FromContext(ctx)
 	logger := log.FromContext(ctx)
+	router, limiter := NewRouter(ctx)
 	s := &HTTPServer{
-		ctx: ctx,
-		cfg: cfg,
+		ctx:         ctx,
+		cfg:         cfg,
+		httpLimiter: limiter,
 		Server: &http.Server{
 			Addr:              cfg.HTTP.ListenAddr,
-			Handler:           NewRouter(ctx),
+			Handler:           router,
 			ReadHeaderTimeout: time.Second * 10,
 			// WriteTimeout and ReadTimeout are intentionally not set: git pack-objects
 			// streams can take hours for large repositories, and a fixed deadline would
@@ -52,6 +55,9 @@ func (s *HTTPServer) SetTLSConfig(tlsConfig *tls.Config) {
 
 // Close closes the HTTP server.
 func (s *HTTPServer) Close() error {
+	if s.httpLimiter != nil {
+		s.httpLimiter.Close()
+	}
 	return s.Server.Close()
 }
 
@@ -89,5 +95,8 @@ func (s *HTTPServer) ListenAndServe() error {
 
 // Shutdown gracefully shuts down the HTTP server.
 func (s *HTTPServer) Shutdown(ctx context.Context) error {
+	if s.httpLimiter != nil {
+		s.httpLimiter.Close()
+	}
 	return s.Server.Shutdown(ctx)
 }

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -58,8 +58,9 @@ func securityHeadersMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-// NewRouter returns a new HTTP router.
-func NewRouter(ctx context.Context) http.Handler {
+// NewRouter returns a new HTTP router and the rate limiter that must be closed
+// when the server shuts down.
+func NewRouter(ctx context.Context) (http.Handler, *ratelimit.IPLimiter) {
 	logger := log.FromContext(ctx).WithPrefix("http")
 	router := mux.NewRouter()
 
@@ -84,10 +85,12 @@ func NewRouter(ctx context.Context) http.Handler {
 	h = securityHeadersMiddleware(h)
 	h = newRateLimitMiddleware(httpLimiter, cfg.HTTP.TrustProxyHeaders)(h)
 
+	// CORS wraps the rate limiter so that OPTIONS preflight requests receive
+	// CORS headers before potentially being rate-limited.
 	h = handlers.CORS(handlers.AllowedHeaders(cfg.HTTP.CORS.AllowedHeaders),
 		handlers.AllowedOrigins(cfg.HTTP.CORS.AllowedOrigins),
 		handlers.AllowedMethods(cfg.HTTP.CORS.AllowedMethods),
 	)(h)
 
-	return h
+	return h, httpLimiter
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/soft-serve/git"
@@ -101,7 +102,13 @@ func SendWebhook(ctx context.Context, w models.Webhook, event Event, payload int
 
 	res, reqErr := do(ctx, w.URL, http.MethodPost, headers, strings.NewReader(reqBody))
 	var reqHeaders string
-	for k, v := range headers {
+	headerKeys := make([]string, 0, len(headers))
+	for k := range headers {
+		headerKeys = append(headerKeys, k)
+	}
+	sort.Strings(headerKeys)
+	for _, k := range headerKeys {
+		v := headers[k]
 		reqHeaders += k + ": " + strings.Join(v, ", ") + "\n"
 	}
 


### PR DESCRIPTION
## Summary
- GenerateToken returns (string, error); CreateAccessToken propagates it (MUST-FIX)
- HTTPServer stores httpLimiter and closes it on shutdown (MUST-FIX)
- ImportRepository uses caller ctx via WithoutCancel (SHOULD-FIX)
- PostReceive: capture user from caller ctx, pass to syncRepoMeta (SHOULD-FIX)
- push mirror git subprocess: minimal env (HOME, PATH, GIT_SSH_COMMAND) (SHOULD-FIX)
- auth: comment on best-effort timing equalization (SHOULD-FIX)
- CORS applied before rate limiter for OPTIONS preflight (NIT)
- webhook headers: sort keys for deterministic ordering (NIT)
- comments: DeleteUser TOCTOU + ImportRepository Exists race (NIT)

Closes #845