### PR TITLE
fix: review-loop round 11 — LFS skip synced objects, IPLimiter sync.Once, upload-pack comment

### DIFF
--- a/pkg/backend/lfs.go
+++ b/pkg/backend/lfs.go
@@ -64,20 +64,26 @@ func StoreRepoMissingLFSObjects(ctx context.Context, repo proto.Repository, dbx 
 			return err
 		}
 
+		if exist && obj.ID != 0 {
+			// fully synced — skip
+			continue
+		}
 		if exist && obj.ID == 0 {
+			// on disk but not in DB — register
 			if err := store.CreateLFSObject(ctx, dbx, repo.ID(), pointer.Oid, pointer.Size); err != nil {
 				return db.WrapError(err)
 			}
-		} else {
-			batch = append(batch, pointer.Pointer)
-			// Limit batch requests to lfsBatchSize objects
-			if len(batch) >= lfsBatchSize {
-				if err := download(batch); err != nil {
-					return err
-				}
-
-				batch = nil
+			continue
+		}
+		// not on disk — add to download batch
+		batch = append(batch, pointer.Pointer)
+		// Limit batch requests to lfsBatchSize objects
+		if len(batch) >= lfsBatchSize {
+			if err := download(batch); err != nil {
+				return err
 			}
+
+			batch = nil
 		}
 	}
 

--- a/pkg/ratelimit/ratelimit.go
+++ b/pkg/ratelimit/ratelimit.go
@@ -14,12 +14,13 @@ import (
 
 // IPLimiter tracks one token-bucket limiter per source IP address.
 type IPLimiter struct {
-	mu      sync.Mutex
-	entries map[string]*ipEntry
-	r       rate.Limit
-	burst   int
-	ttl     time.Duration
-	done    chan struct{}
+	mu         sync.Mutex
+	entries    map[string]*ipEntry
+	r          rate.Limit
+	burst      int
+	ttl        time.Duration
+	done       chan struct{}
+	closeOnce  sync.Once
 }
 
 type ipEntry struct {
@@ -43,7 +44,7 @@ func New(r rate.Limit, burst int, ttl time.Duration) *IPLimiter {
 
 // Close stops the background cleanup goroutine.
 func (il *IPLimiter) Close() {
-	close(il.done)
+	il.closeOnce.Do(func() { close(il.done) })
 }
 
 // Allow returns true if the source IP is within its rate limit.

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -501,6 +501,9 @@ func serviceRpc(w http.ResponseWriter, r *http.Request) {
 	)
 
 	// Handle gzip encoding
+	// Note: git-upload-pack body is not capped by MaxBytesReader — for read-only fetches this is
+	// acceptable since the client only negotiates which objects to send; the upload-pack protocol
+	// does not receive user-controlled blobs.
 	reader = r.Body
 	switch r.Header.Get("Content-Encoding") {
 	case "gzip":


### PR DESCRIPTION
## Summary
- LFS: skip fully-synced objects in StoreRepoMissingLFSObjects (SHOULD-FIX)
- IPLimiter.Close: sync.Once to prevent double-close panic (NIT)
- serviceRpc: comment explaining upload-pack body size trade-off (NIT)

Closes #846