### PR TITLE
fix: review-loop round 13 — receive-pack 10GiB cap, HSTS on TLS, vars file order comment

### DIFF
--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -131,6 +131,9 @@ func withParams(next http.Handler) http.Handler {
 		vars := mux.Vars(r)
 		repo := vars["repo"]
 
+		// Note: vars["file"] is computed using the raw repo segment (before .git stripping)
+		// which is intentional — the file path is relative to the full URL path including
+		// the .git suffix. SanitizeRepo is applied to repo only for backend lookups below.
 		// Construct "file" param from path
 		vars["file"] = strings.TrimPrefix(r.URL.Path, "/"+repo+"/")
 
@@ -496,25 +499,35 @@ func serviceRpc(w http.ResponseWriter, r *http.Request) {
 		cmd.Env = append(cmd.Env, "GIT_PROTOCOL="+gitProtocol)
 	}
 
-	var (
-		err    error
-		reader io.ReadCloser
-	)
+	// maxReceivePackSize is the maximum size of a git-receive-pack request body (10 GiB).
+	// git-upload-pack is left uncapped — for read-only fetches this is acceptable since
+	// the client only negotiates which objects to send; the upload-pack protocol does not
+	// receive user-controlled blobs.
+	const maxReceivePackSize = 10 * 1024 * 1024 * 1024
+
+	var reader io.ReadCloser
+
+	// For receive-pack, cap the body to prevent unbounded uploads.
+	if service == git.ReceivePackService {
+		r.Body = http.MaxBytesReader(w, r.Body, maxReceivePackSize)
+	}
 
 	// Handle gzip encoding
-	// Note: git-upload-pack body is not capped by MaxBytesReader — for read-only fetches this is
-	// acceptable since the client only negotiates which objects to send; the upload-pack protocol
-	// does not receive user-controlled blobs.
 	reader = r.Body
 	switch r.Header.Get("Content-Encoding") {
 	case "gzip":
-		reader, err = gzip.NewReader(reader)
-		if err != nil {
-			logger.Errorf("failed to create gzip reader: %v", err)
+		gzReader, gzErr := gzip.NewReader(reader)
+		if gzErr != nil {
+			logger.Errorf("failed to create gzip reader: %v", gzErr)
 			renderInternalServerError(w, r)
 			return
 		}
-		defer reader.Close() //nolint: errcheck
+		defer gzReader.Close() //nolint: errcheck
+		if service == git.ReceivePackService {
+			reader = io.NopCloser(io.LimitReader(gzReader, maxReceivePackSize))
+		} else {
+			reader = gzReader
+		}
 	}
 
 	cmd.Stdin = reader

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -47,15 +47,22 @@ func newRateLimitMiddleware(limiter *ratelimit.IPLimiter, trustProxyHeaders bool
 	}
 }
 
-// securityHeadersMiddleware sets defensive HTTP response headers.
-func securityHeadersMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Frame-Options", "DENY")
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
-		w.Header().Set("Content-Security-Policy", "default-src 'none'")
-		next.ServeHTTP(w, r)
-	})
+// securityHeadersMiddleware returns middleware that sets defensive HTTP response headers.
+// When TLS is configured (both TLSKeyPath and TLSCertPath are set) it also adds an HSTS header.
+func securityHeadersMiddleware(cfg *config.Config) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("X-Frame-Options", "DENY")
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+			w.Header().Set("Content-Security-Policy", "default-src 'none'")
+			// Only add HSTS when serving over TLS
+			if cfg.HTTP.TLSKeyPath != "" && cfg.HTTP.TLSCertPath != "" {
+				w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 // NewRouter returns a new HTTP router and the rate limiter that must be closed
@@ -83,7 +90,7 @@ func NewRouter(ctx context.Context) (http.Handler, *ratelimit.IPLimiter) {
 	h = gitSuffixMiddleware(cfg)(h)
 	h = handlers.CompressHandler(h)
 	h = handlers.RecoveryHandler()(h)
-	h = securityHeadersMiddleware(h)
+	h = securityHeadersMiddleware(cfg)(h)
 	h = newRateLimitMiddleware(httpLimiter, cfg.HTTP.TrustProxyHeaders)(h)
 
 	// CORS wraps the rate limiter so that OPTIONS preflight requests receive


### PR DESCRIPTION
## Summary
- git-receive-pack: MaxBytesReader(10GiB) + io.LimitReader for gzip path (SHOULD-FIX)
- securityHeadersMiddleware: add HSTS header when TLS certs are configured (NIT)
- git.go: comment explaining vars["file"] intentional ordering (NIT)

Closes #848