### PR TITLE
fix: review-loop round 14 — task p.err data race, ErrTokenExpired, auth log noise, empty root guard

### DIFF
--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -92,6 +92,10 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 			defer cancel()
 			cmd := exec.CommandContext(mirrorCtx, "git", "push", "--mirror", m.RemoteURL)
 			cmd.Dir = repoPath
+			// Note: HOME and PATH are sourced from the current process environment.
+			// If soft-serve runs as a system service with a restricted environment,
+			// these may be empty; in that case, git push may fail. Ensure the service
+			// environment includes a valid PATH (e.g., /usr/bin:/usr/local/bin).
 			cmd.Env = []string{
 				"HOME=" + os.Getenv("HOME"),
 				"PATH=" + os.Getenv("PATH"),

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -111,6 +111,9 @@ func (l *LocalStorage) Rename(oldName, newName string) error {
 // fixPath resolves the storage-relative path and verifies it stays within the root.
 // Replace all slashes with the OS-specific separator.
 func (l LocalStorage) fixPath(path string) (string, error) {
+	if l.root == "" {
+		return "", fmt.Errorf("storage: empty root path")
+	}
 	path = strings.ReplaceAll(path, "/", string(os.PathSeparator))
 	p := filepath.Join(l.root, path)
 	// Ensure the resolved path is within the storage root.

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -22,6 +22,7 @@ type Task struct {
 	started atomic.Bool
 	ctx     context.Context
 	cancel  context.CancelFunc
+	mu      sync.Mutex
 	err     error
 }
 
@@ -86,8 +87,11 @@ func (m *Manager) Run(id string, done chan<- error) {
 	p := v.(*Task)
 	if p.started.Load() {
 		<-p.ctx.Done()
-		if p.err != nil {
-			done <- p.err
+		p.mu.Lock()
+		err := p.err
+		p.mu.Unlock()
+		if err != nil {
+			done <- err
 			return
 		}
 
@@ -108,7 +112,9 @@ func (m *Manager) Run(id string, done chan<- error) {
 	case <-m.ctx.Done():
 		done <- m.ctx.Err()
 	case err := <-errc:
+		p.mu.Lock()
 		p.err = err
+		p.mu.Unlock()
 		m.m.Store(id, p)
 		done <- err
 	}

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -82,11 +82,14 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 		}
 		logger.Debug("trying to authenticate using access token as username", "username", logUser)
 		user, err := be.UserByAccessToken(ctx, username)
+		if errors.Is(err, proto.ErrTokenExpired) {
+			return nil, errInvalidToken
+		}
 		if err == nil {
 			return user, nil
 		}
 
-		logger.Error("failed to get user", "err", err)
+		logger.Debug("failed to get user", "err", err)
 		return nil, errInvalidToken
 	}
 


### PR DESCRIPTION
## Summary
- task.Task: mutex to eliminate p.err data race (MUST-FIX)
- auth: ErrTokenExpired returns errInvalidToken instead of generic error (SHOULD-FIX)
- auth: demote token-not-found log from Error to Debug (SHOULD-FIX)
- storage/local.go: empty root guard in fixPath (NIT)
- push_mirror: comment about HOME/PATH from process env (NIT)

Closes #849