### PR TITLE
fix: review-loop round 15 — ImportRepository SSH SSRF, rate-limit config, RFC5987 filename, webhook multi-delivery

### DIFF
--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -38,6 +38,13 @@ func validateImportRemote(remote string) error {
 		}
 	}
 
+	switch endpoint.Scheme {
+	case "ssh", "git+ssh", "ssh+git":
+		if err := ssrf.ValidateHost(endpoint.Host); err != nil {
+			return fmt.Errorf("import remote: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -118,6 +118,13 @@ type HTTPConfig struct {
 	// for client IP resolution. Only enable this when the server sits behind a
 	// trusted reverse proxy. Default is false.
 	TrustProxyHeaders bool `env:"SOFT_SERVE_HTTP_TRUST_PROXY_HEADERS" yaml:"trust_proxy_headers"`
+
+	// RateLimit is the maximum number of HTTP requests per second per IP.
+	// Set to 0 to disable rate limiting.
+	RateLimit float64 `env:"RATE_LIMIT" yaml:"rate_limit"`
+
+	// RateBurst is the maximum burst size for the HTTP rate limiter.
+	RateBurst int `env:"RATE_BURST" yaml:"rate_burst"`
 }
 
 // StatsConfig is the configuration for the stats server.
@@ -430,6 +437,8 @@ func DefaultConfig() *Config {
 			Enabled:    true,
 			ListenAddr: ":23232",
 			PublicURL:  "http://localhost:23232",
+			RateLimit:  10,
+			RateBurst:  30,
 			CORS: CORSConfig{
 				AllowedHeaders: []string{"Accept", "Accept-Language", "Content-Language", "Content-Type", "Origin", "X-Requested-With", "User-Agent", "Authorization", "Access-Control-Request-Method", "Access-Control-Allow-Origin"},
 				AllowedMethods: []string{"GET", "HEAD", "POST", "PUT", "OPTIONS"},

--- a/pkg/config/file.go
+++ b/pkg/config/file.go
@@ -119,6 +119,12 @@ http:
   # Only enable this when the server sits behind a trusted reverse proxy.
   # trust_proxy_headers: false
 
+  # Maximum HTTP requests per second per IP address. Set to 0 to disable.
+  # rate_limit: 10
+
+  # Maximum burst size for the HTTP rate limiter.
+  # rate_burst: 30
+
   # The cross-origin request security options
   cors:
     # The allowed cross-origin headers

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -51,8 +51,10 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 		if err != nil {
 			// Run a dummy bcrypt comparison to prevent username enumeration via timing.
 			_ = bcrypt.CompareHashAndPassword([]byte(dummyHash), []byte(password))
-			// Timing equalization is best-effort. The DB query has variable latency,
-			// so this is not a constant-time guarantee but reduces the timing gap.
+			// Timing equalization is best-effort: both the "user found" and "user not found"
+			// paths perform one DB lookup and one bcrypt comparison. However, DB query latency
+			// is variable and not constant-time, so this does not provide strong enumeration
+			// resistance — it only reduces the bcrypt-timing gap.
 			// Also attempt token lookup so the not-found and wrong-password paths
 			// do the same amount of work.
 			_, _ = be.UserByAccessToken(ctx, password)

--- a/pkg/web/blob.go
+++ b/pkg/web/blob.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"mime"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -121,10 +122,10 @@ func getRawBlob(w http.ResponseWriter, r *http.Request) {
 	// block must itself be safe to serve without further sanitisation.
 	if r.Header.Get("Accept") == "application/octet-stream" {
 		contentType = "application/octet-stream"
-		// Build a safe filename for Content-Disposition per RFC 6266 §4.3:
-		//  - strip ASCII control characters (0x00-0x1F, 0x7F) to prevent
-		//    response-header injection via crafted filenames
-		//  - escape embedded double-quotes
+		// Build a safe filename for Content-Disposition per RFC 6266 §4.3 and
+		// RFC 5987: strip ASCII control characters to prevent header injection,
+		// then emit both filename= (ASCII fallback) and filename*= (RFC 5987)
+		// forms so all clients get the correct name.
 		rawName := filepath.Base(filePath)
 		safeName := strings.Map(func(r rune) rune {
 			if r < 0x20 || r == 0x7F {
@@ -132,8 +133,26 @@ func getRawBlob(w http.ResponseWriter, r *http.Request) {
 			}
 			return r
 		}, rawName)
-		safeName = strings.ReplaceAll(safeName, `"`, `\"`)
-		w.Header().Set("Content-Disposition", `attachment; filename="`+safeName+`"`)
+		asciiName := strings.ReplaceAll(safeName, `"`, `\"`)
+		// Check whether the name is pure ASCII (no code point above 0x7E).
+		isASCII := true
+		for _, r := range safeName {
+			if r > 0x7E {
+				isASCII = false
+				break
+			}
+		}
+		if isASCII {
+			w.Header().Set("Content-Disposition", `attachment; filename="`+asciiName+`"`)
+		} else {
+			// RFC 5987 encoded filename: UTF-8''<percent-encoded>.
+			// url.PathEscape percent-encodes all non-unreserved characters except '/'.
+			// Replace any literal '/' that might appear in a segment (shouldn't
+			// after filepath.Base, but be safe).
+			encoded := strings.ReplaceAll(url.PathEscape(safeName), "/", "%2F")
+			w.Header().Set("Content-Disposition",
+				`attachment; filename="`+asciiName+`"; filename*=UTF-8''`+encoded)
+		}
 	}
 
 	// Mutable refs (branch names, tags) must not be cached by proxies.

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -80,8 +80,7 @@ func NewRouter(ctx context.Context) (http.Handler, *ratelimit.IPLimiter) {
 	router.PathPrefix("/").HandlerFunc(renderNotFound)
 
 	cfg := config.FromContext(ctx)
-	// TODO: expose HTTP rate-limit parameters in HTTPConfig for operator tuning
-	httpLimiter := ratelimit.New(rate.Limit(100), 200, 10*time.Minute)
+	httpLimiter := ratelimit.New(rate.Limit(cfg.HTTP.RateLimit), cfg.HTTP.RateBurst, 10*time.Minute)
 
 	// Context handler
 	// Adds context to the request
@@ -93,8 +92,9 @@ func NewRouter(ctx context.Context) (http.Handler, *ratelimit.IPLimiter) {
 	h = securityHeadersMiddleware(cfg)(h)
 	h = newRateLimitMiddleware(httpLimiter, cfg.HTTP.TrustProxyHeaders)(h)
 
-	// CORS wraps the rate limiter so that OPTIONS preflight requests receive
-	// CORS headers before potentially being rate-limited.
+	// Note: CORS middleware wraps the rate limiter, so OPTIONS preflight requests
+	// receive CORS headers without consuming rate-limit tokens. This is intentional
+	// to avoid throttling legitimate browsers, but means OPTIONS flood is not limited.
 	h = handlers.CORS(handlers.AllowedHeaders(cfg.HTTP.CORS.AllowedHeaders),
 		handlers.AllowedOrigins(cfg.HTTP.CORS.AllowedOrigins),
 		handlers.AllowedMethods(cfg.HTTP.CORS.AllowedMethods),

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -145,12 +145,15 @@ func SendEvent(ctx context.Context, payload EventPayload) error {
 		return db.WrapError(err)
 	}
 
+	var errs []error
 	for _, w := range webhooks {
 		if err := SendWebhook(ctx, w, payload.Event(), payload); err != nil {
-			return err
+			errs = append(errs, err)
 		}
 	}
-
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- validateImportRemote: add ssrf.ValidateHost for ssh:// and SCP remotes (MUST-FIX)
- HTTPConfig: expose RateLimit/RateBurst (defaults 10/30) instead of hardcoded 100/200 (SHOULD-FIX)
- Content-Disposition: RFC5987 dual filename= / filename*=UTF-8'' for non-ASCII (SHOULD-FIX)
- SendEvent: deliver to all webhooks, collect errors instead of abort-on-first (NIT)
- auth: clarify timing equalization comment (SHOULD-FIX)
- server.go: document OPTIONS preflight rate-limit bypass (NIT)

Closes #850