### PR TITLE
fix: review-loop round 16 — LFS lock path.Clean, mirror timeout bug (1800ns→30m), task Run doc, hooks msg

### DIFF
--- a/pkg/backend/hooks.go
+++ b/pkg/backend/hooks.go
@@ -145,7 +145,7 @@ func (d *Backend) Update(ctx context.Context, _ io.Writer, _ io.Writer, repo str
 			return
 		}
 	} else {
-		d.logger.Error("error finding user")
+		d.logger.Error("error finding user: neither SOFT_SERVE_PUBLIC_KEY nor SOFT_SERVE_USERNAME is set in hook environment")
 		return
 	}
 

--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -110,5 +110,8 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 			}
 		}(m)
 	}
+	// wg.Wait blocks until all concurrency-bounded pushes complete.
+	// PushMirrors itself is called from a goroutine in syncRepoMeta,
+	// so blocking here does not delay the push response to the git client.
 	wg.Wait()
 }

--- a/pkg/jobs/mirror.go
+++ b/pkg/jobs/mirror.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"charm.land/log/v2"
 	"github.com/charmbracelet/soft-serve/git"
@@ -20,6 +21,8 @@ import (
 func init() {
 	Register("mirror-pull", mirrorPull{})
 }
+
+const mirrorPullTimeout = 30 * time.Minute
 
 type mirrorPull struct{}
 
@@ -94,7 +97,7 @@ func (m mirrorPull) Func(ctx context.Context) func() {
 						// in ImportRepository already sets Timeout: -1 for the
 						// same reason. git-module RunInDirWithOptions only applies
 						// a deadline when timeout > 0, so -1 is safe here.
-						cmd := git.NewCommand(args...).WithContext(ctx).WithTimeout(30 * 60)
+						cmd := git.NewCommand(args...).WithContext(ctx).WithTimeout(mirrorPullTimeout)
 						cmd.AddEnvs(sshEnv)
 
 						if _, err := cmd.RunInDir(r.Path); err != nil {

--- a/pkg/store/database/lfs.go
+++ b/pkg/store/database/lfs.go
@@ -2,6 +2,8 @@ package database
 
 import (
 	"context"
+	"fmt"
+	"path"
 	"strings"
 
 	"github.com/charmbracelet/soft-serve/pkg/db"
@@ -13,15 +15,23 @@ type lfsStore struct{}
 
 var _ store.LFSStore = (*lfsStore)(nil)
 
-func sanitizePath(path string) string {
-	path = strings.TrimSpace(path)
-	path = strings.TrimPrefix(path, "/")
-	return path
+func sanitizePath(p string) (string, error) {
+	p = strings.TrimSpace(p)
+	p = strings.TrimPrefix(p, "/")
+	p = path.Clean(p)
+	if strings.HasPrefix(p, "..") {
+		return "", fmt.Errorf("invalid lock path: %q", p)
+	}
+	return p, nil
 }
 
 // CreateLFSLockForUser implements store.LFSStore.
 func (*lfsStore) CreateLFSLockForUser(ctx context.Context, tx db.Handler, repoID int64, userID int64, path string, refname string) error {
-	path = sanitizePath(path)
+	var err error
+	path, err = sanitizePath(path)
+	if err != nil {
+		return err
+	}
 	query := tx.Rebind(`INSERT INTO lfs_locks (repo_id, user_id, path, refname, updated_at)
 		VALUES (
 			?,
@@ -31,7 +41,7 @@ func (*lfsStore) CreateLFSLockForUser(ctx context.Context, tx db.Handler, repoID
 			CURRENT_TIMESTAMP
 		);
 	`)
-	_, err := tx.ExecContext(ctx, query, repoID, userID, path, refname)
+	_, err = tx.ExecContext(ctx, query, repoID, userID, path, refname)
 	return db.WrapError(err)
 }
 
@@ -87,27 +97,35 @@ func (*lfsStore) GetLFSLocksForUser(ctx context.Context, tx db.Handler, repoID i
 
 // GetLFSLocksForPath implements store.LFSStore.
 func (*lfsStore) GetLFSLockForPath(ctx context.Context, tx db.Handler, repoID int64, path string) (models.LFSLock, error) {
-	path = sanitizePath(path)
+	var err error
+	path, err = sanitizePath(path)
+	if err != nil {
+		return models.LFSLock{}, err
+	}
 	var lock models.LFSLock
 	query := tx.Rebind(`
 		SELECT *
 		FROM lfs_locks
 		WHERE repo_id = ? AND path = ?;
 	`)
-	err := tx.GetContext(ctx, &lock, query, repoID, path)
+	err = tx.GetContext(ctx, &lock, query, repoID, path)
 	return lock, db.WrapError(err)
 }
 
 // GetLFSLockForUserPath implements store.LFSStore.
 func (*lfsStore) GetLFSLockForUserPath(ctx context.Context, tx db.Handler, repoID int64, userID int64, path string) (models.LFSLock, error) {
-	path = sanitizePath(path)
+	var err error
+	path, err = sanitizePath(path)
+	if err != nil {
+		return models.LFSLock{}, err
+	}
 	var lock models.LFSLock
 	query := tx.Rebind(`
 		SELECT *
 		FROM lfs_locks
 		WHERE repo_id = ? AND user_id = ? AND path = ?;
 	`)
-	err := tx.GetContext(ctx, &lock, query, repoID, userID, path)
+	err = tx.GetContext(ctx, &lock, query, repoID, userID, path)
 	return lock, db.WrapError(err)
 }
 

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -75,8 +75,10 @@ func (m *Manager) Exists(id string) bool {
 	return ok
 }
 
-// Run starts the task if it exists.
-// Otherwise, it waits for the process to finish.
+// Run starts the task if not already started, or waits for the already-running
+// task to complete and delivers its result to done.
+// Callers MUST ensure done has capacity >= 1 (buffered) to avoid a panic
+// if the caller returns before the task delivers its result.
 func (m *Manager) Run(id string, done chan<- error) {
 	v, ok := m.m.Load(id)
 	if !ok {


### PR DESCRIPTION
## Summary
- LFS sanitizePath: apply path.Clean + reject .. prefix (SHOULD-FIX)
- mirror.go: WithTimeout(30*60) was 1800 nanoseconds — fix to 30*time.Minute (BUG)
- task.Run: document buffered channel requirement (SHOULD-FIX)
- PushMirrors wg.Wait: comment explaining it doesn't block git client (SHOULD-FIX)
- hooks: improve "error finding user" log message (NIT)

Closes #851