### PR TITLE
fix: review-loop round 17 — rate_limit=0 disables, gzip upload-pack LimitReader, hook arg quoting

### DIFF
--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -90,6 +90,8 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 			defer func() { <-sem }() // release
 			mirrorCtx, cancel := context.WithTimeout(ctx, mirrorPushTimeout)
 			defer cancel()
+			// m.RemoteURL is passed as a positional argument to exec.Command (not shell-expanded),
+			// so there is no shell injection risk. SSRF validation has already run above.
 			cmd := exec.CommandContext(mirrorCtx, "git", "push", "--mirror", m.RemoteURL)
 			cmd.Dir = repoPath
 			// Note: HOME and PATH are sourced from the current process environment.

--- a/pkg/backend/user.go
+++ b/pkg/backend/user.go
@@ -308,9 +308,11 @@ func (d *Backend) DeleteUser(ctx context.Context, username string) error {
 		return err
 	}
 
-	// The user record is deleted in one transaction; repo deletions happen
-	// outside that transaction. There is a brief window where repos exist
-	// without an owner. This is accepted as a structural limitation.
+	// NOTE: There is a window between the user-record deletion and repository
+	// deletions below where orphaned repos have no owner. If anonymous access
+	// is enabled and a repo was public, it may be briefly accessible to anon
+	// users. This is a structural limitation; a future improvement would be
+	// to mark repos for deletion atomically inside the user-deletion transaction.
 	// Delete each repository outside the user-deletion transaction to avoid
 	// nested-transaction issues (especially on SQLite).
 	var errs []error

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -120,7 +120,7 @@ type HTTPConfig struct {
 	TrustProxyHeaders bool `env:"SOFT_SERVE_HTTP_TRUST_PROXY_HEADERS" yaml:"trust_proxy_headers"`
 
 	// RateLimit is the maximum number of HTTP requests per second per IP.
-	// Set to 0 to disable rate limiting.
+	// Set to 0 to disable HTTP rate limiting.
 	RateLimit float64 `env:"RATE_LIMIT" yaml:"rate_limit"`
 
 	// RateBurst is the maximum burst size for the HTTP rate limiter.

--- a/pkg/hooks/gen.go
+++ b/pkg/hooks/gen.go
@@ -60,9 +60,9 @@ func GenerateHooks(_ context.Context, cfg *config.Config, repo string) error {
 
 		switch hook {
 		case UpdateHook:
-			args = "$1 $2 $3"
+			args = `"$1" "$2" "$3"`
 		case PostUpdateHook:
-			args = "$@"
+			args = `"$@"`
 		}
 
 		if err := hooksTmpl.Execute(&data, struct {

--- a/pkg/ssh/middleware_test.go
+++ b/pkg/ssh/middleware_test.go
@@ -139,6 +139,7 @@ func TestAuthenticationBypass(t *testing.T) {
 		is.Equal(authenticatedUser.Username(), "testattacker")
 		is.True(!authenticatedUser.IsAdmin())
 
+		// TODO: add integration test that exercises AuthenticationMiddleware directly
 		// In this simulation the mock context still holds the admin user because
 		// AuthenticationMiddleware has NOT been invoked — only the raw backend lookup
 		// above was exercised. In production, AuthenticationMiddleware re-looks up the

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -500,16 +500,19 @@ func serviceRpc(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// maxReceivePackSize is the maximum size of a git-receive-pack request body (10 GiB).
-	// git-upload-pack is left uncapped — for read-only fetches this is acceptable since
-	// the client only negotiates which objects to send; the upload-pack protocol does not
-	// receive user-controlled blobs.
 	const maxReceivePackSize = 10 * 1024 * 1024 * 1024
+
+	// maxUploadPackSize limits upload-pack request bodies. upload-pack only receives
+	// "want" and "have" lines (no actual object data), so 256 MiB is generous.
+	const maxUploadPackSize = 256 * 1024 * 1024
 
 	var reader io.ReadCloser
 
-	// For receive-pack, cap the body to prevent unbounded uploads.
+	// Cap the body for both services to prevent unbounded reads.
 	if service == git.ReceivePackService {
 		r.Body = http.MaxBytesReader(w, r.Body, maxReceivePackSize)
+	} else {
+		r.Body = http.MaxBytesReader(w, r.Body, maxUploadPackSize)
 	}
 
 	// Handle gzip encoding
@@ -526,7 +529,7 @@ func serviceRpc(w http.ResponseWriter, r *http.Request) {
 		if service == git.ReceivePackService {
 			reader = io.NopCloser(io.LimitReader(gzReader, maxReceivePackSize))
 		} else {
-			reader = gzReader
+			reader = io.NopCloser(io.LimitReader(gzReader, maxUploadPackSize))
 		}
 	}
 

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -90,7 +90,9 @@ func NewRouter(ctx context.Context) (http.Handler, *ratelimit.IPLimiter) {
 	h = handlers.CompressHandler(h)
 	h = handlers.RecoveryHandler()(h)
 	h = securityHeadersMiddleware(cfg)(h)
-	h = newRateLimitMiddleware(httpLimiter, cfg.HTTP.TrustProxyHeaders)(h)
+	if cfg.HTTP.RateLimit > 0 {
+		h = newRateLimitMiddleware(httpLimiter, cfg.HTTP.TrustProxyHeaders)(h)
+	}
 
 	// Note: CORS middleware wraps the rate limiter, so OPTIONS preflight requests
 	// receive CORS headers without consuming rate-limit tokens. This is intentional


### PR DESCRIPTION
## Summary
- rate_limit=0 now disables rate limiting instead of blocking all traffic (MUST-FIX)
- serviceRpc: LimitReader(256MB) for upload-pack gzip decompression (SHOULD-FIX)
- Hook scripts: quote positional args "$1" "$2" "$3" and "$@" (SHOULD-FIX)
- user.go: strengthen orphan-repos window comment (SHOULD-FIX)
- push_mirror.go: comment on safe exec (NIT)
- middleware_test: TODO for AuthenticationMiddleware integration test (NIT)

Closes #852