### PR TITLE
fix: review-loop round 18 — go-get private repo leak, timing equalization, access token scope, flush buf

### DIFF
--- a/pkg/backend/access_token.go
+++ b/pkg/backend/access_token.go
@@ -39,11 +39,6 @@ func (b *Backend) CreateAccessToken(ctx context.Context, user proto.User, name s
 // DeleteAccessToken deletes an access token for a user.
 func (b *Backend) DeleteAccessToken(ctx context.Context, user proto.User, id int64) error {
 	err := b.db.TransactionContext(ctx, func(tx *db.Tx) error {
-		_, err := b.store.GetAccessToken(ctx, tx, id)
-		if err != nil {
-			return db.WrapError(err)
-		}
-
 		if err := b.store.DeleteAccessTokenForUser(ctx, tx, user.ID(), id); err != nil {
 			return db.WrapError(err)
 		}

--- a/pkg/backend/hooks.go
+++ b/pkg/backend/hooks.go
@@ -145,7 +145,7 @@ func (d *Backend) Update(ctx context.Context, _ io.Writer, _ io.Writer, repo str
 			return
 		}
 	} else {
-		d.logger.Error("error finding user: neither SOFT_SERVE_PUBLIC_KEY nor SOFT_SERVE_USERNAME is set in hook environment")
+		d.logger.Warn("error finding user: neither SOFT_SERVE_PUBLIC_KEY nor SOFT_SERVE_USERNAME is set in hook environment")
 		return
 	}
 

--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -104,6 +104,8 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 			}
 			if sshCmd := os.Getenv("GIT_SSH_COMMAND"); sshCmd != "" {
 				cmd.Env = append(cmd.Env, "GIT_SSH_COMMAND="+sshCmd)
+			} else if sockPath := os.Getenv("SSH_AUTH_SOCK"); sockPath != "" {
+				cmd.Env = append(cmd.Env, "SSH_AUTH_SOCK="+sockPath)
 			}
 			if out, err := cmd.CombinedOutput(); err != nil {
 				b.logger.Warn("push-mirror: push failed", "repo", repo.Name(), "mirror", m.Name, "err", err, "output", string(out))

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -64,6 +64,9 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 			return user, nil
 		}
 
+		// Dummy bcrypt to equalize timing regardless of user-found vs user-not-found
+		_ = bcrypt.CompareHashAndPassword([]byte(dummyHash), []byte(""))
+
 		// Try to authenticate using access token as the password
 		user, err = be.UserByAccessToken(ctx, password)
 		if err == nil {

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -131,9 +131,8 @@ func withParams(next http.Handler) http.Handler {
 		vars := mux.Vars(r)
 		repo := vars["repo"]
 
-		// Note: vars["file"] is computed using the raw repo segment (before .git stripping)
-		// which is intentional — the file path is relative to the full URL path including
-		// the .git suffix. SanitizeRepo is applied to repo only for backend lookups below.
+		// repo still has the .git suffix here; vars["file"] is the path component after /<repo>/.
+		// SanitizeRepo (applied below) strips the .git suffix from vars["repo"] only.
 		// Construct "file" param from path
 		vars["file"] = strings.TrimPrefix(r.URL.Path, "/"+repo+"/")
 
@@ -424,7 +423,7 @@ func withAccess(next http.Handler) http.HandlerFunc {
 		}
 
 		switch {
-		case r.URL.Query().Get("go-get") == "1" && (accessLevel >= access.ReadOnlyAccess || cfg.AllowPublicGoGet):
+		case r.URL.Query().Get("go-get") == "1" && repo != nil && (accessLevel >= access.ReadOnlyAccess || cfg.AllowPublicGoGet):
 			// Allow go-get requests to passthrough.
 			break
 		case errors.Is(err, errInvalidToken), errors.Is(err, errInvalidPassword):
@@ -554,7 +553,7 @@ type flushResponseWriter struct {
 	http.ResponseWriter
 }
 
-const flushBufSize = 1024
+const flushBufSize = 32 * 1024
 
 func (f *flushResponseWriter) ReadFrom(r io.Reader) (int64, error) {
 	flusher := http.NewResponseController(f.ResponseWriter)


### PR DESCRIPTION
## Summary
- go-get: require repo != nil to prevent private repo existence leak (MUST-FIX)
- auth: symmetric dummy bcrypt on user-found/wrong-password path (SHOULD-FIX)
- access_token: remove unscoped GetAccessToken probe in DeleteAccessToken (SHOULD-FIX)
- push_mirror: forward SSH_AUTH_SOCK when GIT_SSH_COMMAND not set (SHOULD-FIX)
- hooks: Error -> Warn for missing user env vars (NIT)
- git.go: flushBufSize 1024 -> 32*1024 (NIT)
- git.go: clarify vars["file"] comment (NIT)

Closes #853