### PR TITLE
fix: review-loop round 20 — push mirror scheme allowlist, auth comment, orphan-window comment

### DIFF
--- a/pkg/backend/auth.go
+++ b/pkg/backend/auth.go
@@ -35,7 +35,9 @@ func GenerateToken() (string, error) {
 	return "ss_" + hex.EncodeToString(buf), nil
 }
 
-// HashToken hashes the token using sha256.
+// HashToken returns the SHA-256 hex digest of the token. The 20-byte (160-bit)
+// random token provides sufficient entropy to make rainbow-table attacks
+// impractical. A HMAC-with-server-secret scheme would be more defensive.
 func HashToken(token string) string {
 	sum := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(sum[:])

--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
@@ -63,8 +64,8 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 				b.logger.Warn("push mirror: SSRF check failed", "remote", m.RemoteURL, "err", ssrfErr)
 				continue
 			}
-		} else if err == nil && u.Scheme == "ssh" {
-			// Validate ssh:// scheme URLs against SSRF.
+		} else if err == nil && (u.Scheme == "ssh" || u.Scheme == "git+ssh" || u.Scheme == "ssh+git") {
+			// Validate ssh:// / git+ssh:// / ssh+git:// scheme URLs against SSRF.
 			if ssrfErr := ssrf.ValidateHost(u.Hostname()); ssrfErr != nil {
 				b.logger.Warn("push mirror: SSRF check failed", "remote", m.RemoteURL, "err", ssrfErr)
 				continue
@@ -82,6 +83,11 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 					continue
 				}
 			}
+		} else {
+			// Block git:// and any other unrecognized scheme.
+			schemeErr := fmt.Errorf("push mirror: unsupported URL scheme %q", u.Scheme)
+			b.logger.Warn(schemeErr.Error(), "remote", m.RemoteURL)
+			continue
 		}
 		sem <- struct{}{} // acquire
 		wg.Add(1)

--- a/pkg/backend/user.go
+++ b/pkg/backend/user.go
@@ -313,6 +313,8 @@ func (d *Backend) DeleteUser(ctx context.Context, username string) error {
 	// is enabled and a repo was public, it may be briefly accessible to anon
 	// users. This is a structural limitation; a future improvement would be
 	// to mark repos for deletion atomically inside the user-deletion transaction.
+	// Future improvement: set a soft-delete flag on repos inside the user-deletion
+	// transaction so they become invisible immediately before filesystem cleanup.
 	// Delete each repository outside the user-deletion transaction to avoid
 	// nested-transaction issues (especially on SQLite).
 	var errs []error

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -490,6 +490,7 @@ func serviceRpc(w http.ResponseWriter, r *http.Request) {
 		"SOFT_SERVE_LOG_PATH=" + filepath.Join(cfg.DataPath, "log", "hooks.log"),
 	}...)
 	if user != nil {
+		// user.Username() is validated by ValidateUsername (letters/digits/hyphens only) — no injection risk.
 		cmd.Env = append(cmd.Env, []string{
 			"SOFT_SERVE_USERNAME=" + user.Username(),
 		}...)
@@ -623,6 +624,7 @@ func getInfoRefs(w http.ResponseWriter, r *http.Request) {
 			"SOFT_SERVE_LOG_PATH=" + filepath.Join(cfg.DataPath, "log", "hooks.log"),
 		}...)
 		if user != nil {
+			// user.Username() is validated by ValidateUsername (letters/digits/hyphens only) — no injection risk.
 			cmd.Env = append(cmd.Env, []string{
 				"SOFT_SERVE_USERNAME=" + user.Username(),
 			}...)


### PR DESCRIPTION
## Summary
- push_mirror: explicit scheme allowlist; block git:// and unrecognized schemes (MUST-FIX)
- HashToken: add comment about SHA-256 entropy vs HMAC trade-off (NIT)
- user.go: enhance orphan-window comment with soft-delete suggestion (NIT)
- git.go: comment that SOFT_SERVE_USERNAME is already validated (NIT)

(Several fixes were already applied by previous rounds)

Closes #84