### PR TITLE
fix: review-loop round 22 — env tag, LFS batch clarity, ssrf ULA comment, consolidated comment, nolint, StringBuilder

### DIFF
--- a/pkg/backend/user.go
+++ b/pkg/backend/user.go
@@ -309,14 +309,10 @@ func (d *Backend) DeleteUser(ctx context.Context, username string) error {
 	}
 
 	// NOTE: There is a window between the user-record deletion and repository
-	// deletions below where orphaned repos have no owner. If anonymous access
-	// is enabled and a repo was public, it may be briefly accessible to anon
-	// users. This is a structural limitation; a future improvement would be
-	// to mark repos for deletion atomically inside the user-deletion transaction.
-	// Future improvement: set a soft-delete flag on repos inside the user-deletion
-	// transaction so they become invisible immediately before filesystem cleanup.
-	// Delete each repository outside the user-deletion transaction to avoid
-	// nested-transaction issues (especially on SQLite).
+	// deletions below where orphaned repos have no owner. A future improvement
+	// would be to soft-delete repos atomically inside the user-deletion transaction
+	// so they become invisible immediately before filesystem cleanup.
+	// Repos are deleted outside the transaction to avoid nested-transaction issues.
 	var errs []error
 	for _, name := range repoNames {
 		if err := d.DeleteRepository(ctx, name); err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -117,7 +117,7 @@ type HTTPConfig struct {
 	// TrustProxyHeaders controls whether the X-Forwarded-For header is trusted
 	// for client IP resolution. Only enable this when the server sits behind a
 	// trusted reverse proxy. Default is false.
-	TrustProxyHeaders bool `env:"SOFT_SERVE_HTTP_TRUST_PROXY_HEADERS" yaml:"trust_proxy_headers"`
+	TrustProxyHeaders bool `env:"TRUST_PROXY_HEADERS" yaml:"trust_proxy_headers"`
 
 	// RateLimit is the maximum number of HTTP requests per second per IP.
 	// Set to 0 to disable HTTP rate limiting.

--- a/pkg/ssrf/ssrf.go
+++ b/pkg/ssrf/ssrf.go
@@ -86,6 +86,8 @@ func isPrivateOrInternal(ip net.IP) bool {
 		ip = ip4
 	}
 
+	// ip.IsPrivate() covers IPv6 ULA (fc00::/7) and IPv4 private ranges;
+	// no separate fc00::/7 check is needed here.
 	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
 		ip.IsPrivate() || ip.IsUnspecified() || ip.IsMulticast() {
 		return true

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -57,7 +57,7 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 			// resistance — it only reduces the bcrypt-timing gap.
 			// Also attempt token lookup so the not-found and wrong-password paths
 			// do the same amount of work.
-			_, _ = be.UserByAccessToken(ctx, password)
+			_, _ = be.UserByAccessToken(ctx, password) //nolint:errcheck // intentionally discarded for timing equalization
 			return nil, errInvalidPassword
 		}
 		if user != nil && backend.VerifyPassword(password, user.Password()) {

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -154,7 +154,7 @@ func serviceLfsBatch(w http.ResponseWriter, r *http.Request) {
 				})
 
 				// If the object doesn't exist in the database, create it
-				if exist && obj.ID == 0 {
+				if exist && objNotFound {
 					if err := datastore.CreateLFSObject(ctx, dbx, repo.ID(), o.Oid, o.Size); err != nil {
 						logger.Error("error creating object in datastore", "oid", o.Oid, "repo", name, "err", err)
 						renderJSON(w, r, http.StatusInternalServerError, lfs.ErrorResponse{

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -101,16 +101,16 @@ func SendWebhook(ctx context.Context, w models.Webhook, event Event, payload int
 	}
 
 	res, reqErr := do(ctx, w.URL, http.MethodPost, headers, strings.NewReader(reqBody))
-	var reqHeaders string
 	headerKeys := make([]string, 0, len(headers))
 	for k := range headers {
 		headerKeys = append(headerKeys, k)
 	}
 	sort.Strings(headerKeys)
+	var reqHeadersB strings.Builder
 	for _, k := range headerKeys {
-		v := headers[k]
-		reqHeaders += k + ": " + strings.Join(v, ", ") + "\n"
+		reqHeadersB.WriteString(k + ": " + strings.Join(headers[k], ", ") + "\n")
 	}
+	reqHeaders := reqHeadersB.String()
 
 	resStatus := 0
 	resHeaders := ""
@@ -118,9 +118,11 @@ func SendWebhook(ctx context.Context, w models.Webhook, event Event, payload int
 
 	if res != nil {
 		resStatus = res.StatusCode
+		var resHeadersB strings.Builder
 		for k, v := range res.Header {
-			resHeaders += k + ": " + strings.Join(v, ", ") + "\n"
+			resHeadersB.WriteString(k + ": " + strings.Join(v, ", ") + "\n")
 		}
+		resHeaders = resHeadersB.String()
 
 		if res.Body != nil {
 			defer res.Body.Close() //nolint: errcheck


### PR DESCRIPTION
## Summary
- config: TrustProxyHeaders env tag → TRUST_PROXY_HEADERS (prefix-chain convention) (SHOULD-FIX)
- LFS batch: exist && obj.ID == 0 → exist && objNotFound (intent clarity) (SHOULD-FIX)
- ssrf: comment that ip.IsPrivate() covers IPv6 ULA fc00::/7 (SHOULD-FIX)
- user.go: consolidate duplicate orphan-window comment (NIT)
- auth.go: nolint:errcheck on intentionally discarded UserByAccessToken (NIT)
- webhook: strings.Builder for header concatenation (NIT)

Closes #88