### PR TITLE
fix: review-loop round 25 — ipConns memory leak, ImportRepository deadlock, hook error handling

### DIFF
--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -283,7 +283,17 @@ func (d *Backend) ImportRepository(ctx context.Context, name string, user proto.
 		d.manager.Run(tid, done)
 	}()
 
-	return <-repoc, <-done
+	// Both channels are buffered (cap 1). In the normal path p.fn sends to
+	// repoc before returning, then Run delivers to done. In the cancellation
+	// path Run sends to done before p.fn has had a chance to send to repoc;
+	// blocking on <-repoc first would deadlock until the import goroutine
+	// eventually completes. Use select to handle whichever arrives first.
+	select {
+	case r := <-repoc:
+		return r, <-done
+	case err := <-done:
+		return nil, err
+	}
 }
 
 // DeleteRepository deletes a repository.

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -140,7 +140,15 @@ func (d *GitDaemon) Serve(listener net.Listener) error {
 
 		d.wg.Add(1)
 		go func() {
-			defer atomic.AddInt32(ipCount, -1)
+			defer func() {
+				// Decrement the per-IP counter and remove the map entry when it
+				// reaches zero so ipConns does not grow without bound over time.
+				// CompareAndDelete is a no-op if another connection from the same IP
+				// already stored a new counter pointer via LoadOrStore.
+				if atomic.AddInt32(ipCount, -1) == 0 {
+					d.ipConns.CompareAndDelete(remoteIP, ipCount)
+				}
+			}()
 			d.handleClient(conn)
 			d.wg.Done()
 		}()

--- a/pkg/hooks/gen.go
+++ b/pkg/hooks/gen.go
@@ -3,11 +3,11 @@ package hooks
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"text/template"
 
-	"charm.land/log/v2"
 	"github.com/charmbracelet/soft-serve/pkg/config"
 	"github.com/charmbracelet/soft-serve/pkg/utils"
 )
@@ -35,6 +35,7 @@ func GenerateHooks(_ context.Context, cfg *config.Config, repo string) error {
 		return err
 	}
 
+	var errs []error
 	for _, hook := range []string{
 		PreReceiveHook,
 		UpdateHook,
@@ -49,13 +50,15 @@ func GenerateHooks(_ context.Context, cfg *config.Config, repo string) error {
 
 		// Write the hooks primary script
 		if err := os.WriteFile(hp, []byte(hookTemplate), os.ModePerm); err != nil { //nolint:gosec
-			return err
+			errs = append(errs, err)
+			continue
 		}
 
 		// Create ${hook}.d directory.
 		hp += ".d"
 		if err := os.MkdirAll(hp, os.ModePerm); err != nil {
-			return err
+			errs = append(errs, err)
+			continue
 		}
 
 		switch hook {
@@ -74,20 +77,18 @@ func GenerateHooks(_ context.Context, cfg *config.Config, repo string) error {
 			Hook:       hook,
 			Args:       args,
 		}); err != nil {
-			log.WithPrefix("hooks").Error("failed to execute hook template", "err", err)
+			errs = append(errs, err)
 			continue
 		}
 
 		// Write the soft-serve hook inside ${hook}.d directory.
 		hp = filepath.Join(hp, "soft-serve")
-		err := os.WriteFile(hp, data.Bytes(), os.ModePerm) //nolint:gosec
-		if err != nil {
-			log.WithPrefix("hooks").Error("failed to write hook", "err", err)
-			continue
+		if err := os.WriteFile(hp, data.Bytes(), os.ModePerm); err != nil { //nolint:gosec
+			errs = append(errs, err)
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 const (

--- a/pkg/sync/workqueue.go
+++ b/pkg/sync/workqueue.go
@@ -49,6 +49,9 @@ func NewWorkPool(ctx context.Context, workers int, opts ...WorkPoolOption) *Work
 }
 
 // Run starts the workers and waits for them to finish.
+// Jobs added via Add while Run is already executing are not guaranteed to be
+// picked up by the current invocation — they will be processed on the next
+// call to Run. Each job is deleted from the pool when it completes.
 func (wq *WorkPool) Run() {
 	var wg sync.WaitGroup
 

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -88,6 +88,13 @@ func (m *Manager) Run(id string, done chan<- error) {
 
 	p := v.(*Task)
 	if p.started.Load() {
+		// Wait for the already-running task to finish. Note: between
+		// started.Load() returning true and <-p.ctx.Done() completing,
+		// Stop() may call p.cancel() and delete the task from the map.
+		// That is safe — p.ctx.Done() still fires — but p.err may be nil
+		// if p.fn is still running when the context is cancelled. In that
+		// case we fall through to returning p.ctx.Err() (context.Canceled),
+		// which is the correct signal to the caller.
 		<-p.ctx.Done()
 		p.mu.Lock()
 		err := p.err

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -75,10 +75,11 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 
 		// Try to authenticate using access token as the password.
 		// This call also serves timing equalization (mirrors the token lookup in the
-		// user-not-found path above).
-		user, err = be.UserByAccessToken(ctx, password) //nolint:errcheck // timing equalization
-		if err == nil {
-			return user, nil
+		// user-not-found path above). Use distinct variables to avoid reassigning
+		// the outer user on failure.
+		tokenUser, tokenErr := be.UserByAccessToken(ctx, password)
+		if tokenErr == nil {
+			return tokenUser, nil
 		}
 
 		logUsername := username


### PR DESCRIPTION
## Summary
Round 25 automated review-loop fixes: 2 MUST-FIX (memory leak + deadlock), 2 SHOULD-FIX (documentation), 2 NIT (error handling + variable clarity).

## Changes
- `pkg/daemon/daemon.go`: delete ipConns entry when counter reaches 0 — prevents unbounded map growth
- `pkg/backend/repo.go`: use select on repoc/done in ImportRepository — prevents deadlock on context cancellation
- `pkg/task/manager.go`: document ABA/ordering behaviour in already-started branch
- `pkg/sync/workqueue.go`: document concurrent Add behaviour during Run
- `pkg/hooks/gen.go`: collect per-hook errors and return combined error instead of silently continuing
- `pkg/web/auth.go`: use distinct tokenUser/tokenErr variables in access-token fallback path

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/daemon/... ./pkg/backend/... ./pkg/sync/... ./pkg/hooks/... ./pkg/web/...` passes

Closes #93