### PR TITLE
fix: review-loop round 26 — IsZeroHash regex recompile, LFS OID validation, push_mirror split

### DIFF
--- a/git/commit.go
+++ b/git/commit.go
@@ -9,10 +9,14 @@ import (
 // ZeroID is the zero hash.
 const ZeroID = git.EmptyID
 
+// zeroHashPattern matches an all-zero SHA-1 (40 hex zeros) or SHA-256
+// (64 hex zeros) object ID. Compiled once at package init to avoid repeated
+// allocations in hot paths such as webhook delivery and hook arg processing.
+var zeroHashPattern = regexp.MustCompile(`^0{40,}$`)
+
 // IsZeroHash returns whether the hash is a zero hash.
 func IsZeroHash(h string) bool {
-	pattern := regexp.MustCompile(`^0{40,}$`)
-	return pattern.MatchString(h)
+	return zeroHashPattern.MatchString(h)
 }
 
 // Commit is a wrapper around git.Commit with helper methods.

--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -70,8 +70,22 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 				b.logger.Warn("push mirror: SSRF check failed", "remote", m.RemoteURL, "err", ssrfErr)
 				continue
 			}
-		} else if err != nil || u.Scheme == "" {
-			// SCP-style remote (e.g. git@host:repo) — extract host before ':'.
+		} else if err != nil {
+			// url.Parse returned an error — treat as SCP-style remote.
+			raw := m.RemoteURL
+			if at := strings.LastIndex(raw, "@"); at != -1 {
+				raw = raw[at+1:]
+			}
+			if colon := strings.LastIndex(raw, ":"); colon != -1 {
+				host := raw[:colon]
+				host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+				if ssrfErr := ssrf.ValidateHost(host); ssrfErr != nil {
+					b.logger.Warn("push mirror: SSRF check failed", "remote", m.RemoteURL, "err", ssrfErr)
+					continue
+				}
+			}
+		} else if u.Scheme == "" {
+			// No scheme — treat as SCP-style remote (e.g. git@host:repo).
 			raw := m.RemoteURL
 			if at := strings.LastIndex(raw, "@"); at != -1 {
 				raw = raw[at+1:]

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -109,7 +109,7 @@ func (m *Manager) Run(id string, done chan<- error) {
 	}
 
 	p.started.Store(true)
-	m.m.Store(id, p)
+	// m.m already holds p from Add; no re-store needed here.
 	defer p.cancel()
 	defer m.m.Delete(id)
 

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -28,6 +28,11 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// lfsOidPattern matches a valid Git LFS OID in the form "sha256:<64 hex chars>".
+// Compiled once at package init to avoid per-request regexp allocation in LFS
+// handlers (verify, download validation).
+var lfsOidPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
 // serviceLfsBatch handles a Git LFS batch requests.
 // https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md
 // TODO: support refname
@@ -268,6 +273,12 @@ func serviceLfsBasicDownload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate OID explicitly even though the route regex already constrains it,
+	// to guard against future route-regex relaxation.
+	if !lfsOidPattern.MatchString("sha256:" + oid) {
+		renderJSON(w, r, http.StatusUnprocessableEntity, lfs.ErrorResponse{Message: "invalid oid format"})
+		return
+	}
 	pointer := lfs.Pointer{Oid: oid}
 	f, err := strg.Open(path.Join("objects", pointer.RelativePath()))
 	if err != nil {
@@ -419,7 +430,7 @@ func serviceLfsBasicVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if matched, _ := regexp.MatchString(`^sha256:[0-9a-f]{64}$`, pointer.Oid); !matched {
+	if !lfsOidPattern.MatchString(pointer.Oid) {
 		renderJSON(w, r, http.StatusUnprocessableEntity, lfs.ErrorResponse{Message: "invalid oid format"})
 		return
 	}


### PR DESCRIPTION
## Summary
Round 26 fixes: 1 MUST-FIX (hot-path regexp recompile), 2 SHOULD-FIX (LFS OID validation), 2 NIT (code clarity).

## Changes
- `git/commit.go`: package-level `zeroHashPattern` var — avoids regexp recompile on every `IsZeroHash` call
- `pkg/web/git_lfs.go`: `lfsOidPattern` at package scope; used in verify handler and download handler (defence-in-depth)
- `pkg/task/manager.go`: remove redundant `m.m.Store(id, p)` with explanatory comment
- `pkg/backend/push_mirror.go`: split `err!=nil || Scheme==""` into two documented branches

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./git/... ./pkg/web/... ./pkg/backend/...` passes

Closes #95