### PR TITLE
fix: review-loop round 27 — lfsOidPattern regression, dead task Store, push_mirror dedup

### DIFF
--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -70,22 +70,9 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 				b.logger.Warn("push mirror: SSRF check failed", "remote", m.RemoteURL, "err", ssrfErr)
 				continue
 			}
-		} else if err != nil {
-			// url.Parse returned an error — treat as SCP-style remote.
-			raw := m.RemoteURL
-			if at := strings.LastIndex(raw, "@"); at != -1 {
-				raw = raw[at+1:]
-			}
-			if colon := strings.LastIndex(raw, ":"); colon != -1 {
-				host := raw[:colon]
-				host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
-				if ssrfErr := ssrf.ValidateHost(host); ssrfErr != nil {
-					b.logger.Warn("push mirror: SSRF check failed", "remote", m.RemoteURL, "err", ssrfErr)
-					continue
-				}
-			}
-		} else if u.Scheme == "" {
-			// No scheme — treat as SCP-style remote (e.g. git@host:repo).
+		} else if err != nil || u.Scheme == "" {
+			// SCP-style remote (e.g. git@host:repo) — url.Parse either fails or
+			// produces an empty scheme. Both cases require manual host extraction.
 			raw := m.RemoteURL
 			if at := strings.LastIndex(raw, "@"); at != -1 {
 				raw = raw[at+1:]

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -125,7 +125,7 @@ func (m *Manager) Run(id string, done chan<- error) {
 		p.mu.Lock()
 		p.err = err
 		p.mu.Unlock()
-		m.m.Store(id, p)
+		// No re-store: m.m already holds p and defer m.m.Delete(id) runs next.
 		done <- err
 	}
 }

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -28,10 +28,12 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// lfsOidPattern matches a valid Git LFS OID in the form "sha256:<64 hex chars>".
-// Compiled once at package init to avoid per-request regexp allocation in LFS
-// handlers (verify, download validation).
-var lfsOidPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+// lfsOidPattern matches a valid Git LFS bare object ID (64 lowercase hex chars).
+// lfs.Pointer.Oid stores the bare hex internally — the "sha256:" prefix present
+// in pointer files and batch JSON is stripped on parse. Callers must NOT prepend
+// the prefix before matching; the route-level pattern for download also uses bare
+// hex (`[0-9a-f]{64}`).
+var lfsOidPattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
 
 // serviceLfsBatch handles a Git LFS batch requests.
 // https://github.com/git-lfs/git-lfs/blob/main/docs/api/batch.md
@@ -275,7 +277,7 @@ func serviceLfsBasicDownload(w http.ResponseWriter, r *http.Request) {
 
 	// Validate OID explicitly even though the route regex already constrains it,
 	// to guard against future route-regex relaxation.
-	if !lfsOidPattern.MatchString("sha256:" + oid) {
+	if !lfsOidPattern.MatchString(oid) {
 		renderJSON(w, r, http.StatusUnprocessableEntity, lfs.ErrorResponse{Message: "invalid oid format"})
 		return
 	}


### PR DESCRIPTION
## Summary
Round 27 fixes a regression from round 26 and two follow-on cleanups.

## Changes
- `pkg/web/git_lfs.go`: `lfsOidPattern` corrected to `^[0-9a-f]{64}$` — `Pointer.Oid` is bare hex internally; previous `^sha256:[0-9a-f]{64}$` broke the verify handler
- `pkg/task/manager.go`: remove dead `m.m.Store(id, p)` immediately undone by deferred delete
- `pkg/backend/push_mirror.go`: recombine duplicate SCP-parsing blocks into one commented branch

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/web/... ./pkg/backend/...` passes

Closes #97