### PR TITLE
fix: review-loop round 28 — task TOCTOU race, workqueue atomic Add, LFS body drain, UTF-8 fixes

### DIFF
--- a/pkg/backend/hooks.go
+++ b/pkg/backend/hooks.go
@@ -127,7 +127,10 @@ func (d *Backend) PreReceive(_ context.Context, _ io.Writer, _ io.Writer, repo s
 func (d *Backend) Update(ctx context.Context, _ io.Writer, _ io.Writer, repo string, arg hooks.HookArg) {
 	d.logger.Debug("update hook called", "repo", repo, "arg", arg)
 
-	// Find user
+	// Find user from hook environment variables. These are process-global but
+	// safe because each hook invocation is run in a separate subprocess (see
+	// pkg/hooks/gen.go); concurrent pushes in the same server process never
+	// share the hook subprocess's environment.
 	var user proto.User
 	if pubkey := os.Getenv("SOFT_SERVE_PUBLIC_KEY"); pubkey != "" {
 		pk, _, err := sshutils.ParseAuthorizedKey(pubkey)

--- a/pkg/sync/workqueue.go
+++ b/pkg/sync/workqueue.go
@@ -78,12 +78,10 @@ func (wq *WorkPool) Run() {
 }
 
 // Add adds a new job to the pool.
-// If the job already exists, it is a no-op.
+// If the job already exists, it is a no-op. LoadOrStore is used to make
+// the check-and-store atomic and safe for concurrent callers.
 func (wq *WorkPool) Add(id string, fn func()) {
-	if _, ok := wq.work.Load(id); ok {
-		return
-	}
-	wq.work.Store(id, fn)
+	wq.work.LoadOrStore(id, fn)
 }
 
 // Status checks if a job is in the queue.

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -87,14 +87,12 @@ func (m *Manager) Run(id string, done chan<- error) {
 	}
 
 	p := v.(*Task)
-	if p.started.Load() {
-		// Wait for the already-running task to finish. Note: between
-		// started.Load() returning true and <-p.ctx.Done() completing,
-		// Stop() may call p.cancel() and delete the task from the map.
-		// That is safe — p.ctx.Done() still fires — but p.err may be nil
-		// if p.fn is still running when the context is cancelled. In that
-		// case we fall through to returning p.ctx.Err() (context.Canceled),
-		// which is the correct signal to the caller.
+	if !p.started.CompareAndSwap(false, true) {
+		// Task is already running (or was already completed). Wait for it.
+		// Note: between CompareAndSwap returning false and <-p.ctx.Done()
+		// completing, Stop() may cancel the context and delete the map entry —
+		// that is safe because p.ctx.Done() still fires and p is still reachable
+		// through the local pointer.
 		<-p.ctx.Done()
 		p.mu.Lock()
 		err := p.err
@@ -108,7 +106,7 @@ func (m *Manager) Run(id string, done chan<- error) {
 		return
 	}
 
-	p.started.Store(true)
+	// We won the CAS: we are the sole goroutine responsible for running p.fn.
 	// m.m already holds p from Add; no re-store needed here.
 	defer p.cancel()
 	defer m.m.Delete(id)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/x/ansi"
 )
@@ -34,7 +35,8 @@ func ValidateUsername(username string) error {
 		return fmt.Errorf("username cannot be empty")
 	}
 
-	if !unicode.IsLetter(rune(username[0])) {
+	first, _ := utf8.DecodeRuneInString(username)
+	if !unicode.IsLetter(first) {
 		return fmt.Errorf("username must start with a letter")
 	}
 

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -83,16 +83,16 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 		}
 
 		logUsername := username
-		if len(logUsername) > 20 {
-			logUsername = logUsername[:20] + "…"
+		if runes := []rune(logUsername); len(runes) > 20 {
+			logUsername = string(runes[:20]) + "…"
 		}
 		logger.Debug("invalid credentials", "username", logUsername, "err", err)
 		return nil, errInvalidPassword
 	} else if username != "" {
 		// Try to authenticate using access token as the username
 		logUser := username
-		if len(logUser) > 8 {
-			logUser = logUser[:8] + "…"
+		if runes := []rune(logUser); len(runes) > 8 {
+			logUser = string(runes[:8]) + "…"
 		}
 		logger.Debug("trying to authenticate using access token as username", "username", logUser)
 		user, err := be.UserByAccessToken(ctx, username)

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -346,12 +346,12 @@ func serviceLfsBasicUpload(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close() //nolint: errcheck
 
 	// NOTE: Git LFS client will retry uploading the same object if there was a
-	// partial error, so we need to skip existing objects.
+	// partial error, so we need to skip existing objects. Do NOT drain the body
+	// here — the client can send up to 5 GiB and discarding it wastes CPU and
+	// bandwidth. Responding 200 immediately is correct; git-lfs treats a closed
+	// connection on a PUT as a successful upload.
 	if _, err := datastore.GetLFSObjectByOid(ctx, dbx, repo.ID(), oid); err == nil {
-		// Object exists, skip request
-		if _, err := io.Copy(io.Discard, r.Body); err != nil {
-			logger.Debug("discard existing LFS object body", "err", err)
-		}
+		// Object exists, skip request.
 		renderStatus(http.StatusOK)(w, nil)
 		return
 	} else if !errors.Is(err, db.ErrRecordNotFound) {


### PR DESCRIPTION
## Summary
Round 28: 2 MUST-FIX race conditions, 2 SHOULD-FIX, 2 NIT UTF-8 safety fixes.

## Changes
- `pkg/task/manager.go`: CompareAndSwap to prevent concurrent Run double-launch
- `pkg/sync/workqueue.go`: LoadOrStore for atomic Add
- `pkg/web/git_lfs.go`: skip body drain on duplicate LFS upload (up to 5 GiB waste prevented)
- `pkg/backend/hooks.go`: env var safety comment
- `pkg/utils/utils.go`: utf8.DecodeRuneInString for first-char validation
- `pkg/web/auth.go`: rune-safe log truncation

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/task/... ./pkg/sync/... ./pkg/web/... ./pkg/backend/... ./pkg/utils/...` passes

Closes #99