### PR TITLE
fix: review-loop round 31 — SCP SSRF bypass, LFS upload OID validation, description cap, log constant

### DIFF
--- a/pkg/backend/hooks.go
+++ b/pkg/backend/hooks.go
@@ -95,7 +95,12 @@ func (d *Backend) syncRepoMeta(ctx context.Context, repo string, user proto.User
 	}
 
 	if meta.Description != "" {
-		if err := d.SetDescription(ctx, repo, meta.Description); err != nil {
+		const maxDescLen = 2048
+		desc := meta.Description
+		if runes := []rune(desc); len(runes) > maxDescLen {
+			desc = string(runes[:maxDescLen])
+		}
+		if err := d.SetDescription(ctx, repo, desc); err != nil {
 			d.logger.Warnf("post-receive: set description: %v", err)
 		}
 	}

--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -77,13 +77,18 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 			if at := strings.LastIndex(raw, "@"); at != -1 {
 				raw = raw[at+1:]
 			}
-			if colon := strings.LastIndex(raw, ":"); colon != -1 {
-				host := raw[:colon]
-				host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
-				if ssrfErr := ssrf.ValidateHost(host); ssrfErr != nil {
-					b.logger.Warn("push mirror: SSRF check failed", "remote", m.RemoteURL, "err", ssrfErr)
-					continue
-				}
+			colon := strings.LastIndex(raw, ":")
+			if colon == -1 {
+				// No colon means we cannot extract a host — reject to avoid
+				// bypassing SSRF validation on malformed remote URLs.
+				b.logger.Warn("push mirror: cannot extract host from SCP-style remote (no colon)", "remote", m.RemoteURL)
+				continue
+			}
+			host := raw[:colon]
+			host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+			if ssrfErr := ssrf.ValidateHost(host); ssrfErr != nil {
+				b.logger.Warn("push mirror: SSRF check failed", "remote", m.RemoteURL, "err", ssrfErr)
+				continue
 			}
 		} else {
 			// Block git:// and any other unrecognized scheme.

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -15,6 +15,10 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+// maxLogUsernameRunes is the maximum number of runes used when logging a
+// username to avoid leaking long credential strings in log output.
+const maxLogUsernameRunes = 20
+
 // authenticate authenticates the user from the request.
 func authenticate(r *http.Request) (proto.User, error) {
 	// Prefer the Authorization header
@@ -83,16 +87,16 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 		}
 
 		logUsername := username
-		if runes := []rune(logUsername); len(runes) > 20 {
-			logUsername = string(runes[:20]) + "…"
+		if runes := []rune(logUsername); len(runes) > maxLogUsernameRunes {
+			logUsername = string(runes[:maxLogUsernameRunes]) + "…"
 		}
 		logger.Debug("invalid credentials", "username", logUsername, "err", err)
 		return nil, errInvalidPassword
 	} else if username != "" {
 		// Try to authenticate using access token as the username
 		logUser := username
-		if runes := []rune(logUser); len(runes) > 8 {
-			logUser = string(runes[:8]) + "…"
+		if runes := []rune(logUser); len(runes) > maxLogUsernameRunes {
+			logUser = string(runes[:maxLogUsernameRunes]) + "…"
 		}
 		logger.Debug("trying to authenticate using access token as username", "username", logUser)
 		user, err := be.UserByAccessToken(ctx, username)

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -335,6 +335,14 @@ func serviceLfsBasicUpload(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	oid := mux.Vars(r)["oid"]
+
+	// Validate OID explicitly for defence-in-depth (route regex already
+	// constrains it, but this guards against future route-regex relaxation).
+	if !lfsOidPattern.MatchString(oid) {
+		renderJSON(w, r, http.StatusUnprocessableEntity, lfs.ErrorResponse{Message: "invalid oid format"})
+		return
+	}
+
 	cfg := config.FromContext(ctx)
 	dbx := db.FromContext(ctx)
 	datastore := store.FromContext(ctx)


### PR DESCRIPTION
## Summary
Round 31: 1 MUST-FIX SSRF bypass in push mirror, 2 SHOULD-FIX, 1 NIT.

## Changes
- `pkg/backend/push_mirror.go`: reject SCP remotes with no colon (would skip SSRF check)
- `pkg/web/git_lfs.go`: OID validation in upload handler (defence-in-depth, consistent with download/verify)
- `pkg/backend/hooks.go`: cap `.soft-serve.yaml` description to 2048 runes
- `pkg/web/auth.go`: `maxLogUsernameRunes = 20` constant, applied to both truncation sites

Closes #103