### PR TITLE
fix: review-loop round 32 — UpdateWebhook Sanitize, LFS upload repo nil check

### DIFF
--- a/pkg/backend/webhooks.go
+++ b/pkg/backend/webhooks.go
@@ -138,7 +138,9 @@ func (b *Backend) UpdateWebhook(ctx context.Context, repo proto.Repository, id i
 	dbx := db.FromContext(ctx)
 	datastore := store.FromContext(ctx)
 
-	// Validate webhook URL to prevent SSRF attacks
+	// Sanitize and validate webhook URL — mirrors CreateWebhook which also
+	// calls utils.Sanitize before ValidateWebhookURL.
+	url = utils.Sanitize(url)
 	if err := webhook.ValidateWebhookURL(url); err != nil {
 		return err
 	}

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -348,6 +348,10 @@ func serviceLfsBasicUpload(w http.ResponseWriter, r *http.Request) {
 	datastore := store.FromContext(ctx)
 	logger := log.FromContext(ctx).WithPrefix("http.lfs-basic")
 	repo := proto.RepositoryFromContext(ctx)
+	if repo == nil {
+		renderStatus(http.StatusNotFound)(w, r)
+		return
+	}
 	repoID := strconv.FormatInt(repo.ID(), 10)
 	strg := storage.NewLocalStorage(filepath.Join(cfg.DataPath, "lfs", repoID))
 


### PR DESCRIPTION
## Summary
Round 32: 2 SHOULD-FIX consistency issues.

## Changes
- `pkg/backend/webhooks.go`: `utils.Sanitize(url)` in UpdateWebhook before SSRF validation
- `pkg/web/git_lfs.go`: repo nil guard in upload handler (consistent with download/verify)

Closes #105