### PR TITLE
fix: review-loop round 33 — daemon host sanitization, task Run docs, auth timing comment

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -252,7 +252,15 @@ func (d *GitDaemon) handleClient(conn net.Conn) {
 			return
 		}
 
-		host := strings.TrimPrefix(string(opts[1]), "host=")
+		rawHost := strings.TrimPrefix(string(opts[1]), "host=")
+		// Sanitize host value for control characters before it enters the
+		// process environment (newlines in env blocks corrupt other vars).
+		host, hostOK := sanitizeParamValue(rawHost)
+		if !hostOK {
+			d.logger.Warnf("git: rejecting connection with invalid host value %q", rawHost)
+			d.fatal(c, git.ErrInvalidRequest)
+			return
+		}
 		extraParams := map[string]string{}
 
 		if len(opts) > 2 {

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -79,6 +79,10 @@ func (m *Manager) Exists(id string) bool {
 // task to complete and delivers its result to done.
 // Callers MUST ensure done has capacity >= 1 (buffered) to avoid a panic
 // if the caller returns before the task delivers its result.
+//
+// If Stop() is called while a second goroutine is waiting on an already-started
+// task, done receives context.Canceled. Callers should treat context.Canceled as
+// "task was stopped or the manager shut down", not necessarily as a task error.
 func (m *Manager) Run(id string, done chan<- error) {
 	v, ok := m.m.Load(id)
 	if !ok {

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -71,10 +71,10 @@ func parseUsernamePassword(ctx context.Context, username, password string) (prot
 			return user, nil
 		}
 
-		// Dummy bcrypt to equalize timing regardless of user-found vs user-not-found.
-		// Both the "user not found" path (above) and this "user found, wrong password"
-		// path perform one bcrypt comparison and one UserByAccessToken call, so
-		// timing is equalized across both paths.
+		// Second bcrypt to equalize timing: the "user not found" path above performs
+		// one dummy bcrypt + one UserByAccessToken. This "user found, wrong password"
+		// path already ran one REAL bcrypt inside VerifyPassword, so this second call
+		// makes both paths total two bcrypt operations.
 		_ = bcrypt.CompareHashAndPassword([]byte(dummyHash), []byte(password))
 
 		// Try to authenticate using access token as the password.


### PR DESCRIPTION
## Summary
Round 33: 2 SHOULD-FIX, 1 NIT.

## Changes
- `pkg/daemon/daemon.go`: sanitize `host=` pktline value for control chars before SOFT_SERVE_HOST env
- `pkg/task/manager.go`: document context.Canceled semantics for stopped-task waiters
- `pkg/web/auth.go`: clarify timing equalization — dummy bcrypt is second of two calls

Closes #107