### PR TITLE
fix: review-loop round 34 — LFS batch cap, task goroutine drain, ErrorResponse

### DIFF
--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -123,6 +123,12 @@ func (m *Manager) Run(id string, done chan<- error) {
 	select {
 	case <-m.ctx.Done():
 		done <- m.ctx.Err()
+		// The p.fn goroutine may still be running. Drain errc in the background
+		// so it does not block forever on the send; p.cancel() (deferred above)
+		// signals p.fn to stop. The id is deleted from the map by the deferred
+		// m.m.Delete, so no new task with the same id can reuse this Task until
+		// p.fn has sent on errc and this goroutine has exited.
+		go func() { <-errc }()
 	case err := <-errc:
 		p.mu.Lock()
 		p.err = err

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -86,6 +86,17 @@ func serviceLfsBatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Cap the number of objects per batch request to prevent a single
+	// request from triggering thousands of sequential DB + FS round-trips.
+	// 1 000 matches the GitHub LFS limit and is sufficient for real clients.
+	const maxBatchObjects = 1000
+	if len(batchRequest.Objects) > maxBatchObjects {
+		renderJSON(w, r, http.StatusUnprocessableEntity, lfs.ErrorResponse{
+			Message: fmt.Sprintf("batch request exceeds maximum object count of %d", maxBatchObjects),
+		})
+		return
+	}
+
 	name := mux.Vars(r)["repo"]
 	repo := proto.RepositoryFromContext(ctx)
 	if repo == nil {
@@ -484,9 +495,7 @@ func serviceLfsBasicVerify(w http.ResponseWriter, r *http.Request) {
 			renderJSON(w, r, http.StatusOK, map[string]string{"message": "verified"})
 			return
 		}
-		renderJSON(w, r, http.StatusUnprocessableEntity, struct {
-			Message string `json:"message"`
-		}{"size mismatch"})
+		renderJSON(w, r, http.StatusUnprocessableEntity, lfs.ErrorResponse{Message: "size mismatch"})
 		return
 	} else if errors.Is(err, fs.ErrNotExist) {
 		logger.Error("file not found", "oid", pointer.Oid)


### PR DESCRIPTION
## Summary
Round 34: 2 SHOULD-FIX, 1 NIT.

## Changes
- `pkg/web/git_lfs.go`: 1000-object cap on LFS batch; `lfs.ErrorResponse` for size mismatch
- `pkg/task/manager.go`: background goroutine drains `errc` after `m.ctx.Done` to prevent leak

Closes #109