### PR TITLE
fix: suppress errInvalidPassword from error log in withAccess middleware

### DIFF
--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -277,6 +277,7 @@ func withAccess(next http.Handler) http.HandlerFunc {
 		if err != nil {
 			switch {
 			case errors.Is(err, errInvalidToken):
+			case errors.Is(err, errInvalidPassword):
 			case errors.Is(err, proto.ErrUserNotFound):
 			default:
 				logger.Error("failed to authenticate", "err", err)


### PR DESCRIPTION
## Summary
Round 36: add `errInvalidPassword` to the auth-failure silence switch in `withAccess` to stop bad passwords from logging at error level.

Closes #111