### PR TITLE
fix: review-loop round 37 — webhook delete guard, CORS docs, task delete race, stale comment

### DIFF
--- a/pkg/backend/webhooks.go
+++ b/pkg/backend/webhooks.go
@@ -166,15 +166,18 @@ func (b *Backend) UpdateWebhook(ctx context.Context, repo proto.Repository, id i
 		for _, e := range updatedEvents {
 			updatedSet[e] = true
 		}
-		toBeDeleted := make([]int64, 0)
+		var toBeDeleted []int64
 		for _, e := range currentEvents {
 			if !updatedSet[webhook.Event(e.Event)] {
 				toBeDeleted = append(toBeDeleted, e.ID)
 			}
 		}
 
-		if err := datastore.DeleteWebhookEventsByID(ctx, tx, toBeDeleted); err != nil {
-			return db.WrapError(err)
+		// Guard the delete call: sqlx.In returns an error for empty slices.
+		if len(toBeDeleted) > 0 {
+			if err := datastore.DeleteWebhookEventsByID(ctx, tx, toBeDeleted); err != nil {
+				return db.WrapError(err)
+			}
 		}
 
 		// Prune events that are already in the list.

--- a/pkg/store/database/webhooks.go
+++ b/pkg/store/database/webhooks.go
@@ -73,7 +73,7 @@ func (*webhookStore) DeleteWebhookDeliveryByID(ctx context.Context, h db.Handler
 	return err
 }
 
-// DeleteWebhookEventsByWebhookID implements store.WebhookStore.
+// DeleteWebhookEventsByID implements store.WebhookStore.
 func (*webhookStore) DeleteWebhookEventsByID(ctx context.Context, h db.Handler, ids []int64) error {
 	query, args, err := sqlx.In(`DELETE FROM webhook_events WHERE id IN (?);`, ids)
 	if err != nil {

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -113,7 +113,6 @@ func (m *Manager) Run(id string, done chan<- error) {
 	// We won the CAS: we are the sole goroutine responsible for running p.fn.
 	// m.m already holds p from Add; no re-store needed here.
 	defer p.cancel()
-	defer m.m.Delete(id)
 
 	errc := make(chan error, 1)
 	go func(ctx context.Context) {
@@ -123,17 +122,19 @@ func (m *Manager) Run(id string, done chan<- error) {
 	select {
 	case <-m.ctx.Done():
 		done <- m.ctx.Err()
-		// The p.fn goroutine may still be running. Drain errc in the background
-		// so it does not block forever on the send; p.cancel() (deferred above)
-		// signals p.fn to stop. The id is deleted from the map by the deferred
-		// m.m.Delete, so no new task with the same id can reuse this Task until
-		// p.fn has sent on errc and this goroutine has exited.
-		go func() { <-errc }()
+		// Delay map deletion until the p.fn goroutine has fully exited so that
+		// a concurrent Add(id, ...) + Run(id, ...) cannot start a new task for
+		// the same id while the old goroutine is still executing p.fn.
+		go func() {
+			<-errc
+			m.m.Delete(id)
+		}()
 	case err := <-errc:
 		p.mu.Lock()
 		p.err = err
 		p.mu.Unlock()
-		// No re-store: m.m already holds p and defer m.m.Delete(id) runs next.
+		// No re-store: m.m already holds p; delete after storing the result.
+		m.m.Delete(id)
 		done <- err
 	}
 }

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -94,6 +94,12 @@ func NewRouter(ctx context.Context) (http.Handler, *ratelimit.IPLimiter) {
 	// preflights receive CORS headers even when rate-limited (the browser needs
 	// those headers to understand the 429 response). All request methods,
 	// including OPTIONS, consume rate-limit tokens.
+	//
+	// AllowCredentials is explicitly NOT set (defaults to false). Wildcard
+	// AllowedOrigins ("*") is incompatible with credential-carrying requests;
+	// browsers reject Access-Control-Allow-Credentials: true when the origin
+	// is "*". Operators who need credentialed cross-origin access must specify
+	// explicit origins in the CORS config.
 	h = handlers.CORS(handlers.AllowedHeaders(cfg.HTTP.CORS.AllowedHeaders),
 		handlers.AllowedOrigins(cfg.HTTP.CORS.AllowedOrigins),
 		handlers.AllowedMethods(cfg.HTTP.CORS.AllowedMethods),


### PR DESCRIPTION
## Summary
Round 37: 1 MUST-FIX, 2 SHOULD-FIX, 2 NIT.

## Changes
- `pkg/backend/webhooks.go`: guard empty `toBeDeleted` delete; `var` decl
- `pkg/web/server.go`: CORS credential/wildcard incompatibility documented
- `pkg/task/manager.go`: delay map delete until drain goroutine exits
- `pkg/store/database/webhooks.go`: fix stale comment

Closes #113