### PR TITLE
fix(daemon): return ErrNotAuthed for missing repos to prevent enumeration

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -307,10 +307,10 @@ func (d *GitDaemon) handleClient(conn net.Conn) {
 		}
 
 		if _, err := d.be.Repository(ctx, repo); err != nil {
-			// Note: returning ErrInvalidRepo for non-existent repos leaks repo names to
-			// unauthenticated clients. A future improvement would return a uniform
-			// ErrNotAuthed regardless of whether the repo exists.
-			d.fatal(c, git.ErrInvalidRepo)
+			// Return ErrNotAuthed (not ErrInvalidRepo) so that the response is
+			// indistinguishable from an access-denial. Returning ErrInvalidRepo
+			// would let unauthenticated clients enumerate which repositories exist.
+			d.fatal(c, git.ErrNotAuthed)
 			return
 		}
 


### PR DESCRIPTION
## Summary
Returns `git.ErrNotAuthed` uniformly when a repository is not found in the git daemon, so the error response is indistinguishable from an access-denial. Previously returning `git.ErrInvalidRepo` allowed unauthenticated clients to enumerate which repositories exist on the server.

## Changes
- `pkg/daemon/daemon.go:309-315`: Changed `d.fatal(c, git.ErrInvalidRepo)` → `d.fatal(c, git.ErrNotAuthed)` in the repo existence check; updated comment

## Test plan
- [ ] Build passes: `go build ./pkg/daemon/...`
- [ ] A client requesting a non-existent repo now receives the same error as when access is denied

Closes #115