### PR TITLE
fix(review-39): hooks echo injection, task nil return, ssrf ctx-aware DNS, webhook guard, daemon wg defer

### DIFF
--- a/pkg/backend/hooks.go
+++ b/pkg/backend/hooks.go
@@ -60,6 +60,9 @@ func (d *Backend) syncRepoMeta(ctx context.Context, repo string, user proto.User
 	}
 
 	// Trigger push mirrors asynchronously.
+	// TODO: PushMirrors runs synchronously and may be cancelled by the
+	// caller's 30-second context before a slow mirror completes.
+	// Consider giving push mirrors their own context with a longer timeout.
 	d.PushMirrors(ctx, r)
 
 	gr, err := r.Open()

--- a/pkg/backend/webhooks.go
+++ b/pkg/backend/webhooks.go
@@ -188,8 +188,10 @@ func (b *Backend) UpdateWebhook(ctx context.Context, repo proto.Repository, id i
 			}
 		}
 
-		if err := datastore.CreateWebhookEvents(ctx, tx, id, newEvents); err != nil {
-			return db.WrapError(err)
+		if len(newEvents) > 0 {
+			if err := datastore.CreateWebhookEvents(ctx, tx, id, newEvents); err != nil {
+				return db.WrapError(err)
+			}
 		}
 
 		return nil

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -140,6 +140,7 @@ func (d *GitDaemon) Serve(listener net.Listener) error {
 
 		d.wg.Add(1)
 		go func() {
+			defer d.wg.Done()
 			defer func() {
 				// Decrement the per-IP counter and remove the map entry when it
 				// reaches zero so ipConns does not grow without bound over time.
@@ -150,7 +151,6 @@ func (d *GitDaemon) Serve(listener net.Listener) error {
 				}
 			}()
 			d.handleClient(conn)
-			d.wg.Done()
 		}()
 	}
 }

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -102,8 +102,10 @@ func TestInvalidRepo(t *testing.T) {
 		t.Fatalf("expected nil, got error: %v", err)
 	}
 	_, err = readPktline(c)
-	if err != nil && err.Error() != git.ErrInvalidRepo.Error() {
-		t.Errorf("expected %q error, got %q", git.ErrInvalidRepo, err)
+	// Non-existent repos now return ErrNotAuthed (same as access-denied) to
+	// prevent unauthenticated clients from enumerating repository existence.
+	if err != nil && err.Error() != git.ErrNotAuthed.Error() {
+		t.Errorf("expected %q error, got %q", git.ErrNotAuthed, err)
 	}
 }
 

--- a/pkg/hooks/gen.go
+++ b/pkg/hooks/gen.go
@@ -105,7 +105,7 @@ for hook in ${GIT_DIR}/hooks/${hookname}.d/*; do
   test -x "${hook}" && test -f "${hook}" || continue
 
   # Run the actual hook
-  echo "${data}" | "${hook}" "$@"
+  printf '%s' "${data}" | "${hook}" "$@"
 
   # Store the exit code for later use
   exitcodes="${exitcodes} $?"

--- a/pkg/ssrf/ssrf.go
+++ b/pkg/ssrf/ssrf.go
@@ -39,19 +39,21 @@ func NewSecureClient() *http.Client {
 
 				ip := net.ParseIP(host)
 				if ip == nil {
-					ips, err := net.LookupIP(host) //nolint
+					// Use the context-aware resolver so the lookup respects
+					// cancellation and deadlines from the caller.
+					addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 					if err != nil {
 						return nil, fmt.Errorf("DNS resolution failed for host %s: %v", host, err)
 					}
-					if len(ips) == 0 {
+					if len(addrs) == 0 {
 						return nil, fmt.Errorf("no IP addresses found for host: %s", host)
 					}
-					for _, candidate := range ips {
-						if isPrivateOrInternal(candidate) {
+					for _, addr := range addrs {
+						if isPrivateOrInternal(addr.IP) {
 							return nil, fmt.Errorf("%w", ErrPrivateIP)
 						}
 					}
-					ip = ips[0]
+					ip = addrs[0].IP
 				}
 				if isPrivateOrInternal(ip) {
 					return nil, fmt.Errorf("%w", ErrPrivateIP)

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -106,7 +106,10 @@ func (m *Manager) Run(id string, done chan<- error) {
 			return
 		}
 
-		done <- p.ctx.Err()
+		// p.err == nil: task completed successfully; p.cancel() fired after fn
+		// returned. Return nil so callers distinguish clean completion from a
+		// context cancellation caused by Stop() or manager shutdown.
+		done <- nil
 		return
 	}
 


### PR DESCRIPTION
## Summary
Round 39 fixes: correctness and security hardening across multiple packages.

## Changes
- `pkg/hooks/gen.go`: `printf '%s'` instead of `echo` — prevents echo flag/backslash interpretation on hook stdin
- `pkg/task/manager.go`: second waiter returns `nil` when task completed cleanly (was returning spurious `context.Canceled`)
- `pkg/ssrf/ssrf.go`: context-aware `LookupIPAddr` in dial transport (DNS now respects context cancellation/deadlines)
- `pkg/backend/webhooks.go`: guard `CreateWebhookEvents` with `len(newEvents) > 0`
- `pkg/daemon/daemon.go`: `defer d.wg.Done()` so WaitGroup is decremented even on panic
- `pkg/daemon/daemon_test.go`: update `TestInvalidRepo` to expect `ErrNotAuthed` (consistent with round-38 fix)
- `pkg/backend/hooks.go`: TODO comment on push-mirror timeout

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/task/... ./pkg/ssrf/... ./pkg/hooks/... ./pkg/daemon/... ./pkg/backend/...` passes

Closes #117