### PR TITLE
fix(review-41): ValidateWebhookURL ctx, daemon max-conn, bulk INSERT, symlink guard, CORS warn

### DIFF
--- a/pkg/backend/hooks.go
+++ b/pkg/backend/hooks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/charmbracelet/soft-serve/git"
@@ -194,19 +193,9 @@ func (d *Backend) Update(ctx context.Context, _ io.Writer, _ io.Writer, repo str
 func (d *Backend) PostUpdate(ctx context.Context, _ io.Writer, _ io.Writer, repo string, args ...string) {
 	d.logger.Debug("post-update hook called", "repo", repo, "args", args)
 
-	var wg sync.WaitGroup
-
-	// Populate last-modified file.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if err := populateLastModified(ctx, d, repo); err != nil {
-			d.logger.Error("error populating last-modified", "repo", repo, "err", err)
-			return
-		}
-	}()
-
-	wg.Wait()
+	if err := populateLastModified(ctx, d, repo); err != nil {
+		d.logger.Error("error populating last-modified", "repo", repo, "err", err)
+	}
 }
 
 func populateLastModified(ctx context.Context, d *Backend, name string) error {

--- a/pkg/backend/webhooks.go
+++ b/pkg/backend/webhooks.go
@@ -26,7 +26,7 @@ func (b *Backend) CreateWebhook(ctx context.Context, repo proto.Repository, url 
 	}
 
 	// Validate webhook URL to prevent SSRF attacks
-	if err := webhook.ValidateWebhookURL(url); err != nil {
+	if err := webhook.ValidateWebhookURL(ctx, url); err != nil {
 		return err //nolint:wrapcheck
 	}
 
@@ -141,7 +141,7 @@ func (b *Backend) UpdateWebhook(ctx context.Context, repo proto.Repository, id i
 	// Sanitize and validate webhook URL — mirrors CreateWebhook which also
 	// calls utils.Sanitize before ValidateWebhookURL.
 	url = utils.Sanitize(url)
-	if err := webhook.ValidateWebhookURL(url); err != nil {
+	if err := webhook.ValidateWebhookURL(ctx, url); err != nil {
 		return err
 	}
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -116,8 +116,9 @@ func (d *GitDaemon) Serve(listener net.Listener) error {
 			return err
 		}
 
-		// Close connection if there are too many open connections.
-		if d.conns.Size()+1 >= d.cfg.Git.MaxConnections {
+		// Close connection if we are already at the configured limit.
+		// Using >= (not >) ensures MaxConnections is the inclusive cap.
+		if d.conns.Size() >= d.cfg.Git.MaxConnections {
 			d.logger.Debugf("git: max connections reached, closing %s", conn.RemoteAddr())
 			d.fatal(conn, git.ErrMaxConnections)
 			continue

--- a/pkg/store/database/webhooks.go
+++ b/pkg/store/database/webhooks.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"context"
+	"strings"
 
 	"github.com/charmbracelet/soft-serve/pkg/db"
 	"github.com/charmbracelet/soft-serve/pkg/db/models"
@@ -41,15 +42,19 @@ func (*webhookStore) CreateWebhookDelivery(ctx context.Context, h db.Handler, id
 
 // CreateWebhookEvents implements store.WebhookStore.
 func (*webhookStore) CreateWebhookEvents(ctx context.Context, h db.Handler, webhookID int64, events []int) error {
-	query := h.Rebind(`INSERT INTO webhook_events (webhook_id, event)
-			VALUES (?, ?);`)
-	for _, event := range events {
-		_, err := h.ExecContext(ctx, query, webhookID, event)
-		if err != nil {
-			return err
-		}
+	if len(events) == 0 {
+		return nil
 	}
-	return nil
+	// Bulk INSERT to avoid N round-trips for webhooks with many events.
+	placeholders := make([]string, len(events))
+	args := make([]interface{}, 0, len(events)*2)
+	for i, event := range events {
+		placeholders[i] = "(?, ?)"
+		args = append(args, webhookID, event)
+	}
+	query := h.Rebind(`INSERT INTO webhook_events (webhook_id, event) VALUES ` + strings.Join(placeholders, ", "))
+	_, err := h.ExecContext(ctx, query, args...)
+	return err
 }
 
 // DeleteWebhookByID implements store.WebhookStore.

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -150,7 +150,8 @@ func parseAuthHdr(r *http.Request) (proto.User, error) {
 			return nil, err
 		}
 
-		// Find the user
+		// Find the user. Subject is "<username>#<id>"; the '#' separator is
+		// safe because ValidateUsername disallows '#' in usernames.
 		parts := strings.SplitN(claims.Subject, "#", 2)
 		if len(parts) != 2 {
 			logger.Error("invalid jwt subject", "subject", claims.Subject)

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -707,8 +707,15 @@ func sendFile(contentType string, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	f, err := os.Stat(reqFile)
+	// Use Lstat to avoid following symlinks. Symlinks inside a git
+	// repository's info/ or objects/ directories are unexpected and
+	// could point outside the repository root.
+	f, err := os.Lstat(reqFile)
 	if os.IsNotExist(err) {
+		renderNotFound(w, r)
+		return
+	}
+	if f.Mode()&os.ModeSymlink != 0 {
 		renderNotFound(w, r)
 		return
 	}

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -105,6 +105,18 @@ func NewRouter(ctx context.Context) (http.Handler, *ratelimit.IPLimiter) {
 	// browsers reject Access-Control-Allow-Credentials: true when the origin
 	// is "*". Operators who need credentialed cross-origin access must specify
 	// explicit origins in the CORS config.
+	for _, origin := range cfg.HTTP.CORS.AllowedOrigins {
+		if origin == "*" {
+			for _, header := range cfg.HTTP.CORS.AllowedHeaders {
+				if strings.EqualFold(header, "Authorization") {
+					logger.Warn("CORS: wildcard AllowedOrigins with Authorization in AllowedHeaders — " +
+						"any origin can trigger credentialless requests; consider restricting AllowedOrigins")
+					break
+				}
+			}
+			break
+		}
+	}
 	h = handlers.CORS(handlers.AllowedHeaders(cfg.HTTP.CORS.AllowedHeaders),
 		handlers.AllowedOrigins(cfg.HTTP.CORS.AllowedOrigins),
 		handlers.AllowedMethods(cfg.HTTP.CORS.AllowedMethods),


### PR DESCRIPTION
## Summary
Round 41 fixes: build-breaking regression + correctness/security/performance improvements.

## Changes
- `pkg/backend/webhooks.go`: pass `ctx` to `ValidateWebhookURL` (build-breaking regression from round 40)
- `pkg/daemon/daemon.go`: off-by-one fix — `Size >= MaxConnections` (not `Size+1 >= MaxConnections`)
- `pkg/store/database/webhooks.go`: bulk INSERT for webhook events (N round-trips → 1)
- `pkg/web/git.go`: `os.Lstat` + symlink rejection in `sendFile` to block out-of-repo symlink traversal
- `pkg/web/server.go`: startup `Warn` when `AllowedOrigins=["*"]` and `Authorization` in `AllowedHeaders`
- `pkg/web/auth.go`: comment explaining `#`-separator safety in bearer JWT subject
- `pkg/backend/hooks.go`: remove unnecessary `sync.WaitGroup` in `PostUpdate`; drop unused `sync` import

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/backend/... ./pkg/daemon/... ./pkg/store/... ./pkg/web/... ./pkg/webhook/...` passes

Closes #121