### PR TITLE
fix(review-42): task completed ordering, IPv6 zone bypass, LFS 413, go-get comment

### DIFF
--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -90,6 +90,12 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 			}
 			host := raw[:colon]
 			host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+			// Strip IPv6 zone identifier (e.g. "::1%eth0" -> "::1") before
+			// validation. Some platforms resolve scoped addresses successfully,
+			// which could let ::1%zone bypass the loopback check in ValidateHost.
+			if z := strings.IndexByte(host, '%'); z != -1 {
+				host = host[:z]
+			}
 			if ssrfErr := ssrf.ValidateHost(ctx, host); ssrfErr != nil {
 				b.logger.Warn("push mirror: SSRF check failed", "remote", m.RemoteURL, "err", ssrfErr)
 				continue

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -147,6 +147,12 @@ func (d *GitDaemon) Serve(listener net.Listener) error {
 				// reaches zero so ipConns does not grow without bound over time.
 				// CompareAndDelete is a no-op if another connection from the same IP
 				// already stored a new counter pointer via LoadOrStore.
+				//
+				// Known limitation: there is a brief window between AddInt32
+				// returning 0 and CompareAndDelete completing. A new connection in
+				// that window reuses the stale pointer and may find its map entry
+				// deleted, temporarily bypassing the per-IP cap. The global
+				// d.conns limit still guards against DoS.
 				if atomic.AddInt32(ipCount, -1) == 0 {
 					d.ipConns.CompareAndDelete(remoteIP, ipCount)
 				}

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -20,7 +20,11 @@ type Task struct {
 	id        string
 	fn        func(context.Context) error
 	started   atomic.Bool
-	completed atomic.Bool // set true after p.err is written, before p.cancel fires
+	// completed must be stored only AFTER p.err is written and p.mu is
+	// unlocked. A concurrent waiter observing completed==true via its own
+	// p.mu.Lock() is then guaranteed to see the final value of p.err.
+	// Never move this Store before p.mu.Unlock() or the ordering guarantee breaks.
+	completed atomic.Bool
 	ctx       context.Context
 	cancel    context.CancelFunc
 	mu        sync.Mutex

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -429,7 +429,11 @@ func withAccess(next http.Handler) http.HandlerFunc {
 
 		switch {
 		case r.URL.Query().Get("go-get") == "1" && repo != nil && (accessLevel >= access.ReadOnlyAccess || cfg.AllowPublicGoGet):
-			// Allow go-get requests to passthrough.
+			// Allow go-get requests to pass through.
+			// Note: when AllowPublicGoGet is true, unauthenticated clients can
+			// learn that a private repo exists by comparing go-get (200) vs a
+			// regular (404) response. This is an accepted trade-off for go module
+			// discoverability.
 			break
 		case errors.Is(err, errInvalidToken), errors.Is(err, errInvalidPassword):
 			// return 403 when bad credentials are provided

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -54,9 +54,16 @@ func serviceLfsBatch(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close() //nolint: errcheck
 	if err := json.NewDecoder(r.Body).Decode(&batchRequest); err != nil {
 		logger.Errorf("error decoding json: %s", err)
-		renderJSON(w, r, http.StatusUnprocessableEntity, lfs.ErrorResponse{
-			Message: "invalid request body",
-		})
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			renderJSON(w, r, http.StatusRequestEntityTooLarge, lfs.ErrorResponse{
+				Message: "request body too large",
+			})
+		} else {
+			renderJSON(w, r, http.StatusUnprocessableEntity, lfs.ErrorResponse{
+				Message: "invalid request body",
+			})
+		}
 		return
 	}
 

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -85,7 +85,12 @@ func NewRouter(ctx context.Context) (http.Handler, *ratelimit.IPLimiter) {
 	router.PathPrefix("/").HandlerFunc(renderNotFound)
 
 	cfg := config.FromContext(ctx)
-	httpLimiter := ratelimit.New(rate.Limit(cfg.HTTP.RateLimit), cfg.HTTP.RateBurst, 10*time.Minute)
+	// Only create the rate limiter (and its background cleanup goroutine) when
+	// rate limiting is actually enabled. Callers handle a nil limiter.
+	var httpLimiter *ratelimit.IPLimiter
+	if cfg.HTTP.RateLimit > 0 {
+		httpLimiter = ratelimit.New(rate.Limit(cfg.HTTP.RateLimit), cfg.HTTP.RateBurst, 10*time.Minute)
+	}
 
 	// Context handler
 	// Adds context to the request


### PR DESCRIPTION
## Summary
Round 42: 2 MUST-FIX + SHOULD-FIX/NIT hardening.

## Changes
- `pkg/task/manager.go`: Document `completed` field ordering invariant
- `pkg/backend/push_mirror.go`: Strip `%zone` from IPv6 scoped addresses before SSRF validation
- `pkg/daemon/daemon.go`: Document per-IP counter TOCTOU race window
- `pkg/web/git_lfs.go`: Return 413 on `MaxBytesError` in LFS batch requests
- `pkg/web/git.go`: Comment explaining go-get+AllowPublicGoGet repo-existence tradeoff
- `pkg/web/server.go`: Conditionally create httpLimiter only when rate limiting is enabled

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/task/... ./pkg/backend/... ./pkg/web/... ./pkg/daemon/...` passes

Closes #123