### PR TITLE
fix: round 43 — task delete ordering, serviceRpc WriteHeader, auth log level, webhook batch

### DIFF
--- a/pkg/store/database/webhooks.go
+++ b/pkg/store/database/webhooks.go
@@ -130,19 +130,35 @@ func (*webhookStore) GetWebhookEventsByWebhookID(ctx context.Context, h db.Handl
 	return whes, err
 }
 
+// sqliteMaxPlaceholders is the maximum number of placeholders SQLite allows in
+// a single query (SQLITE_MAX_VARIABLE_NUMBER, default 999). We batch queries
+// larger than this to stay within the limit on both SQLite and PostgreSQL.
+const sqliteMaxPlaceholders = 999
+
 // GetWebhookEventsByWebhookIDs implements store.WebhookStore.
 func (*webhookStore) GetWebhookEventsByWebhookIDs(ctx context.Context, h db.Handler, webhookIDs []int64) ([]models.WebhookEvent, error) {
 	if len(webhookIDs) == 0 {
 		return nil, nil
 	}
-	query, args, err := sqlx.In(`SELECT * FROM webhook_events WHERE webhook_id IN (?);`, webhookIDs)
-	if err != nil {
-		return nil, err
+	var all []models.WebhookEvent
+	for i := 0; i < len(webhookIDs); i += sqliteMaxPlaceholders {
+		end := i + sqliteMaxPlaceholders
+		if end > len(webhookIDs) {
+			end = len(webhookIDs)
+		}
+		batch := webhookIDs[i:end]
+		query, args, err := sqlx.In(`SELECT * FROM webhook_events WHERE webhook_id IN (?);`, batch)
+		if err != nil {
+			return nil, err
+		}
+		query = h.Rebind(query)
+		var whes []models.WebhookEvent
+		if err := h.SelectContext(ctx, &whes, query, args...); err != nil {
+			return nil, err
+		}
+		all = append(all, whes...)
 	}
-	query = h.Rebind(query)
-	var whes []models.WebhookEvent
-	err = h.SelectContext(ctx, &whes, query, args...)
-	return whes, err
+	return all, nil
 }
 
 // GetWebhooksByRepoID implements store.WebhookStore.

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -152,8 +152,11 @@ func (m *Manager) Run(id string, done chan<- error) {
 		// concurrent waiter on <-p.ctx.Done() sees completed=true and
 		// returns nil rather than ctx.Err() for a successfully-finished task.
 		p.completed.Store(true)
-		// No re-store: m.m already holds p; delete after storing the result.
-		m.m.Delete(id)
+		// Deliver the result first, then remove from map. A concurrent
+		// Run() arriving between Delete and done<-err would get ErrNotFound;
+		// by deleting after the send, any such caller simply misses this task
+		// (it has already completed) rather than observing an inconsistent state.
 		done <- err
+		m.m.Delete(id)
 	}
 }

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -139,7 +139,8 @@ func parseAuthHdr(r *http.Request) (proto.User, error) {
 	case "token":
 		user, err := be.UserByAccessToken(ctx, parts[1])
 		if err != nil {
-			logger.Error("failed to get user", "err", err)
+			// Use Debug to avoid logging token material at Error level.
+			logger.Debug("failed to get user by access token", "err", err)
 			return nil, err
 		}
 

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -465,12 +465,6 @@ func serviceRpc(w http.ResponseWriter, r *http.Request) {
 		gitHttpReceiveCounter.WithLabelValues(repoName).Inc()
 	}
 
-	w.Header().Set("Content-Type", fmt.Sprintf("application/x-%s-result", service))
-	w.Header().Set("Connection", "Keep-Alive")
-	w.Header().Set("Transfer-Encoding", "chunked")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
-	w.WriteHeader(http.StatusOK)
-
 	gitProtocol := r.Header.Get("Git-Protocol")
 	// Sanitize: reject any control characters to prevent env var injection.
 	for _, c := range gitProtocol {
@@ -524,7 +518,8 @@ func serviceRpc(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, maxUploadPackSize)
 	}
 
-	// Handle gzip encoding
+	// Handle gzip encoding before committing to 200 OK so we can still
+	// return an error status if the gzip stream is malformed.
 	reader = r.Body
 	switch r.Header.Get("Content-Encoding") {
 	case "gzip":
@@ -541,6 +536,14 @@ func serviceRpc(w http.ResponseWriter, r *http.Request) {
 			reader = io.NopCloser(io.LimitReader(gzReader, maxUploadPackSize))
 		}
 	}
+
+	// WriteHeader is deferred until after all request parsing so that
+	// parsing errors (e.g. bad gzip stream above) can return a non-200 status.
+	w.Header().Set("Content-Type", fmt.Sprintf("application/x-%s-result", service))
+	w.Header().Set("Connection", "Keep-Alive")
+	w.Header().Set("Transfer-Encoding", "chunked")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
 
 	cmd.Stdin = reader
 	cmd.Stdout = &flushResponseWriter{w}


### PR DESCRIPTION
## Summary
- `pkg/task/manager.go`: deliver result before deleting from map (prevents ErrNotFound race)
- `pkg/web/git.go`: move `WriteHeader(200)` after gzip reader setup (errors can now return non-200)
- `pkg/web/auth.go`: Token scheme failure now logged at `Debug` instead of `Error`
- `pkg/store/database/webhooks.go`: batch IN-queries at 999 IDs to respect SQLite placeholder limit

## Changes
- `pkg/task/manager.go` — swap Delete/send order
- `pkg/web/git.go` — defer WriteHeader past gzip reader construction
- `pkg/web/auth.go` — logger.Error → logger.Debug for token lookup failure
- `pkg/store/database/webhooks.go` — chunked batch query (sqliteMaxPlaceholders = 999)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/task/... ./pkg/web/... ./pkg/store/... ./pkg/backend/...` all pass

Closes #125