### PR TITLE
fix: round 44 — PushMirrors context, XFF IP validation, task waiter ordering, webhook delivery limit

### DIFF
--- a/pkg/backend/hooks.go
+++ b/pkg/backend/hooks.go
@@ -58,10 +58,12 @@ func (d *Backend) syncRepoMeta(ctx context.Context, repo string, user proto.User
 		return
 	}
 
-	// Trigger push mirrors synchronously. PushMirrors will be interrupted
-	// if ctx expires (30-second default), so slow mirrors may not complete.
-	// TODO: run push mirrors with their own context and a longer timeout.
-	d.PushMirrors(ctx, r)
+	// Run push mirrors with a separate context derived from the backend's root
+	// context so they are not limited by the 30-second syncCtx. Each mirror
+	// goroutine inside PushMirrors creates its own per-push timeout via
+	// mirrorPushTimeout; using the backend root context here lets that inner
+	// timeout operate at full duration.
+	d.PushMirrors(d.ctx, r)
 
 	gr, err := r.Open()
 	if err != nil {

--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -128,7 +128,16 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 			if sshCmd := os.Getenv("GIT_SSH_COMMAND"); sshCmd != "" {
 				cmd.Env = append(cmd.Env, "GIT_SSH_COMMAND="+sshCmd)
 			} else if sockPath := os.Getenv("SSH_AUTH_SOCK"); sockPath != "" {
-				cmd.Env = append(cmd.Env, "SSH_AUTH_SOCK="+sockPath)
+				// SSH_AUTH_SOCK is a Unix socket path from the process environment.
+				// It is not influenced by user input (mirror URLs are validated
+				// separately), so forwarding it here is safe. A newline in this
+				// value would malform the env block; os.Getenv strips NUL bytes
+				// but not newlines — reject the value if it contains one.
+				if strings.ContainsAny(sockPath, "\n\r\x00") {
+					b.logger.Warn("push-mirror: SSH_AUTH_SOCK contains unsafe characters, skipping agent forwarding")
+				} else {
+					cmd.Env = append(cmd.Env, "SSH_AUTH_SOCK="+sockPath)
+				}
 			}
 			if out, err := cmd.CombinedOutput(); err != nil {
 				b.logger.Warn("push-mirror: push failed", "repo", repo.Name(), "mirror", m.Name, "err", err, "output", string(out))

--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -333,11 +333,11 @@ func (d *Backend) DeleteRepository(ctx context.Context, name string) error {
 			return proto.ErrRepoNotFound
 		}
 
-		// If the repo is not in the database but the directory exists, remove it
-		if dberr != nil && ferr == nil {
+		// If the repo is not in the database but the directory exists, remove it.
+		// The previous guard (dberr!=nil && ferr!=nil) already returned, so
+		// the only remaining dberr!=nil case here is dberr!=nil && ferr==nil.
+		if dberr != nil {
 			return os.RemoveAll(rp)
-		} else if dberr != nil {
-			return db.WrapError(dberr)
 		}
 
 		repoID := strconv.FormatInt(repom.ID, 10)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -344,11 +344,8 @@ func (d *GitDaemon) handleClient(conn net.Conn) {
 					d.logger.Warnf("git: ignoring unknown extra param key %q", k)
 					continue
 				}
-				sk, ok := sanitizeParamValue(k)
-				if !ok {
-					d.logger.Warnf("git: dropping extra param with unsafe key %q", k)
-					continue
-				}
+				// k is already confirmed to be "version" (ASCII-safe); only
+				// the value needs sanitization for control-character injection.
 				sv, ok := sanitizeParamValue(v)
 				if !ok {
 					d.logger.Warnf("git: dropping extra param with unsafe value for key %q", k)
@@ -357,7 +354,7 @@ func (d *GitDaemon) handleClient(conn net.Conn) {
 				if len(gitProto) > 0 {
 					gitProto += ":"
 				}
-				gitProto += sk + "=" + sv
+				gitProto += k + "=" + sv
 			}
 			if gitProto != "" {
 				envs = append(envs, "GIT_PROTOCOL="+gitProto)

--- a/pkg/hooks/gen.go
+++ b/pkg/hooks/gen.go
@@ -99,6 +99,8 @@ const (
 data=$(cat)
 exitcodes=""
 hookname=$(basename "$0")
+# $0 is set by git to the path of the hook script itself — not from user input.
+# The command substitution $(dirname "$0") is therefore safe.
 GIT_DIR=${GIT_DIR:-$(dirname "$0")/..}
 for hook in ${GIT_DIR}/hooks/${hookname}.d/*; do
   # Avoid running non-executable hooks

--- a/pkg/store/database/webhooks.go
+++ b/pkg/store/database/webhooks.go
@@ -185,11 +185,16 @@ func (*webhookStore) GetWebhooksByRepoIDWhereEvent(ctx context.Context, h db.Han
 	return whs, err
 }
 
+// maxListWebhookDeliveries caps the number of rows returned by
+// ListWebhookDeliveriesByWebhookID to prevent unbounded memory use for
+// high-volume webhooks. Callers that need more deliveries should paginate.
+const maxListWebhookDeliveries = 100
+
 // ListWebhookDeliveriesByWebhookID implements store.WebhookStore.
 func (*webhookStore) ListWebhookDeliveriesByWebhookID(ctx context.Context, h db.Handler, webhookID int64) ([]models.WebhookDelivery, error) {
-	query := h.Rebind(`SELECT id, response_status, event FROM webhook_deliveries WHERE webhook_id = ?;`)
+	query := h.Rebind(`SELECT id, response_status, event FROM webhook_deliveries WHERE webhook_id = ? ORDER BY created_at DESC LIMIT ?;`)
 	var whds []models.WebhookDelivery
-	err := h.SelectContext(ctx, &whds, query, webhookID)
+	err := h.SelectContext(ctx, &whds, query, webhookID, maxListWebhookDeliveries)
 	return whds, err
 }
 

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -102,25 +102,27 @@ func (m *Manager) Run(id string, done chan<- error) {
 		// completing, Stop() may cancel the context and delete the map entry —
 		// that is safe because p.ctx.Done() still fires and p is still reachable
 		// through the local pointer.
+		// Block until the task's context is done. The winner calls p.cancel()
+		// via defer AFTER writing p.err and storing p.completed=true, so by
+		// the time <-p.ctx.Done() returns, both writes are visible (Go memory
+		// model: the defer executes after the preceding statements, providing
+		// happens-before from the stores to the channel close).
 		<-p.ctx.Done()
-		p.mu.Lock()
-		err := p.err
-		p.mu.Unlock()
-		if err != nil {
+
+		// Check completed first: if true, the task finished normally and p.err
+		// holds the authoritative result (nil or non-nil). We must read p.err
+		// under the mutex to synchronise with the write in the winner path.
+		if p.completed.Load() {
+			p.mu.Lock()
+			err := p.err
+			p.mu.Unlock()
 			done <- err
 			return
 		}
 
-		if p.completed.Load() {
-			// Task completed with a nil error; p.cancel() fired via defer
-			// after the result was stored. Return nil (success).
-			done <- nil
-			return
-		}
-
-		// Context was cancelled before the task finished (Stop() was called
-		// or the manager shut down). Return the context error so callers
-		// can detect the stop signal rather than mistaking it for success.
+		// completed is false: p.cancel() was called by Stop() or the manager
+		// shutting down before the task finished. Return the context error so
+		// callers can distinguish a premature stop from a task error.
 		done <- p.ctx.Err()
 		return
 	}

--- a/pkg/web/auth.go
+++ b/pkg/web/auth.go
@@ -47,6 +47,8 @@ var errInvalidPassword = errors.New("invalid password")
 
 // dummyHash is a bcrypt hash used to equalize timing when user doesn't exist.
 // This prevents username enumeration via timing differences.
+// The value is intentionally public — it is never compared against a real
+// secret; it exists solely to force the bcrypt cost to be paid on every path.
 const dummyHash = "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy"
 
 func parseUsernamePassword(ctx context.Context, username, password string) (proto.User, error) {

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -27,10 +27,18 @@ func realClientIP(r *http.Request, trustProxyHeaders bool) string {
 	if trustProxyHeaders {
 		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
 			// The leftmost IP is the original client.
+			var candidate string
 			if idx := strings.IndexByte(xff, ','); idx != -1 {
-				return strings.TrimSpace(xff[:idx])
+				candidate = strings.TrimSpace(xff[:idx])
+			} else {
+				candidate = strings.TrimSpace(xff)
 			}
-			return strings.TrimSpace(xff)
+			// Validate that the candidate is a real IP address before using it
+			// as the rate-limit key. An attacker who can set X-Forwarded-For
+			// could otherwise bypass per-IP limiting with arbitrary strings.
+			if net.ParseIP(candidate) != nil {
+				return candidate
+			}
 		}
 	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)


### PR DESCRIPTION
## Summary
- `pkg/backend/hooks.go`: give PushMirrors the backend root context, not the 30s sync context
- `pkg/web/server.go`: validate XFF candidate with net.ParseIP before using as rate-limit key
- `pkg/task/manager.go`: check completed first in waiter path; improve ordering comments
- `pkg/store/database/webhooks.go`: add LIMIT 100 + ORDER BY to ListWebhookDeliveriesByWebhookID
- `pkg/backend/repo.go`: remove dead else-if branch
- `pkg/daemon/daemon.go`: remove dead key-sanitization step in version-only loop
- `pkg/backend/push_mirror.go`: reject SSH_AUTH_SOCK with newlines/NUL
- `pkg/web/auth.go`: clarify dummyHash is intentionally public
- `pkg/hooks/gen.go`: add $0 safety comment

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/task/... ./pkg/web/... ./pkg/store/... ./pkg/backend/... ./pkg/daemon/... ./pkg/hooks/...` all pass

Closes #127