### PR TITLE
fix: round 45 — update hook comment, getInfoRefs flush writer

### DIFF
--- a/pkg/backend/hooks.go
+++ b/pkg/backend/hooks.go
@@ -171,8 +171,9 @@ func (d *Backend) Update(ctx context.Context, _ io.Writer, _ io.Writer, repo str
 		return
 	}
 
-	// TODO: run this async
-	// This would probably need something like an RPC server to communicate with the hook process.
+	// Webhook delivery runs synchronously in the update hook subprocess.
+	// Async dispatch would require an IPC channel between the hook process
+	// and the main server; not currently implemented.
 	if git.IsZeroHash(arg.OldSha) || git.IsZeroHash(arg.NewSha) {
 		wh, err := webhook.NewBranchTagEvent(ctx, user, r, arg.RefName, arg.OldSha, arg.NewSha)
 		if err != nil {

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -662,10 +662,13 @@ func getInfoRefs(w http.ResponseWriter, r *http.Request) {
 		hdrNocache(w)
 		w.Header().Set("Content-Type", fmt.Sprintf("application/x-%s-advertisement", service))
 		w.WriteHeader(http.StatusOK)
+		// Use flushResponseWriter so that the pktline header and ref
+		// advertisement are flushed through buffering proxies promptly.
+		fw := &flushResponseWriter{w}
 		if version < 2 {
-			git.WritePktline(w, "# service="+service.String()) //nolint: errcheck
+			git.WritePktline(fw, "# service="+service.String()) //nolint: errcheck
 		}
-		w.Write(refs.Bytes()) //nolint: errcheck
+		fw.Write(refs.Bytes()) //nolint: errcheck
 	} else {
 		// Dumb HTTP
 		updateServerInfo(ctx, dir) //nolint: errcheck


### PR DESCRIPTION
## Summary
- `pkg/backend/hooks.go`: remove stale TODO, add accurate comment about synchronous webhook delivery
- `pkg/web/git.go`: use `flushResponseWriter` for info/refs response

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/web/... ./pkg/backend/...` passes

Closes #129