### PR TITLE
fix: round 47 — LFS delete errors, webhook limits, file:// comment, sort comment

### DIFF
--- a/git/commit.go
+++ b/git/commit.go
@@ -33,6 +33,9 @@ func (cl Commits) Len() int { return len(cl) }
 func (cl Commits) Swap(i, j int) { cl[i], cl[j] = cl[j], cl[i] }
 
 // Less implements sort.Interface.
+// Sorts by author date (not committer date) so the displayed order matches
+// the original authorship timeline. Cherry-picks and rebases will therefore
+// appear at the position of their original authoring, not the rebase time.
 func (cl Commits) Less(i, j int) bool {
 	return cl[i].Author.When.After(cl[j].Author.When)
 }

--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -101,7 +101,9 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 				continue
 			}
 		} else {
-			// Block git:// and any other unrecognized scheme.
+			// Block git://, file://, and any other unrecognized scheme.
+			// file:// could allow access to local filesystem paths and is
+			// blocked here even though it does not carry a network host.
 			schemeErr := fmt.Errorf("push mirror: unsupported URL scheme %q", u.Scheme)
 			b.logger.Warn(schemeErr.Error(), "remote", m.RemoteURL)
 			continue

--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -349,6 +349,7 @@ func (d *Backend) DeleteRepository(ctx context.Context, name string) error {
 			return db.WrapError(err)
 		}
 
+		var lfsErrs []error
 		for _, obj := range objs {
 			p := lfs.Pointer{
 				Oid:  obj.Oid,
@@ -358,7 +359,11 @@ func (d *Backend) DeleteRepository(ctx context.Context, name string) error {
 			d.logger.Debug("deleting lfs object", "repo", name, "oid", obj.Oid)
 			if err := strg.Delete(path.Join("objects", p.RelativePath())); err != nil {
 				d.logger.Error("failed to delete lfs object", "repo", name, "err", err, "oid", obj.Oid)
+				lfsErrs = append(lfsErrs, err)
 			}
+		}
+		if len(lfsErrs) > 0 {
+			return errors.Join(lfsErrs...)
 		}
 
 		if err := d.store.DeleteRepoByName(ctx, tx, name); err != nil {

--- a/pkg/store/database/webhooks.go
+++ b/pkg/store/database/webhooks.go
@@ -163,11 +163,15 @@ func (*webhookStore) GetWebhookEventsByWebhookIDs(ctx context.Context, h db.Hand
 	return all, nil
 }
 
+// maxWebhooksPerRepo caps the number of webhooks returned per repository to
+// prevent unbounded memory use for repos with many configured webhooks.
+const maxWebhooksPerRepo = 100
+
 // GetWebhooksByRepoID implements store.WebhookStore.
 func (*webhookStore) GetWebhooksByRepoID(ctx context.Context, h db.Handler, repoID int64) ([]models.Webhook, error) {
-	query := h.Rebind(`SELECT * FROM webhooks WHERE repo_id = ?;`)
+	query := h.Rebind(`SELECT * FROM webhooks WHERE repo_id = ? LIMIT ?;`)
 	var whs []models.Webhook
-	err := h.SelectContext(ctx, &whs, query, repoID)
+	err := h.SelectContext(ctx, &whs, query, repoID, maxWebhooksPerRepo)
 	return whs, err
 }
 

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -134,6 +134,10 @@ func (m *Manager) Run(id string, done chan<- error) {
 
 	errc := make(chan error, 1)
 	go func(ctx context.Context) {
+		// If p.fn panics, the deferred recover fires before errc<-p.fn(ctx)
+		// produces a value (a panic unwinds the call stack without returning),
+		// so the recover-path send on errc cannot race with the normal-path send.
+		// If p.fn returns normally, recover() returns nil and the if is skipped.
 		defer func() {
 			if r := recover(); r != nil {
 				errc <- fmt.Errorf("task panicked: %v", r)

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -77,6 +77,12 @@ var (
 // without the .git suffix when cfg.HTTP.StripGitSuffix is true.
 // It inserts ".git" before any recognised git sub-path so that all
 // downstream handlers continue to see the canonical /<name>.git/... form.
+// gitSuffixMiddleware handles the StripGitSuffix config option. Despite the
+// flag name "StripGitSuffix", this middleware INSERTS ".git" into the URL
+// path for clients that omit it. The name refers to the client-side
+// perspective: clients may strip ".git" from the clone URL and still reach
+// the server correctly. The middleware re-adds it so downstream handlers see
+// the canonical ".git"-suffixed path.
 func gitSuffixMiddleware(cfg *config.Config) func(http.Handler) http.Handler {
 	// Known sub-paths that immediately follow the repo segment.
 	gitSubPaths := []string{


### PR DESCRIPTION
## Summary
- `pkg/backend/repo.go`: LFS delete errors now returned via errors.Join
- `pkg/store/database/webhooks.go`: GetWebhooksByRepoID capped at 100 rows
- `pkg/backend/push_mirror.go`: file:// scheme explicitly documented as blocked
- `pkg/task/manager.go`: clarify panic vs normal-return ordering comment
- `pkg/web/git.go`: clarify gitSuffixMiddleware INSERTS .git
- `git/commit.go`: explain author-date sort order

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/task/... ./pkg/web/... ./pkg/backend/... ./pkg/store/... ./git/...` passes

Closes #133