### PR TITLE
fix: round 48 — ImportRepository race, SSRF IP selection, SCP host helper

### DIFF
--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -77,24 +77,10 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 		} else if err != nil || u.Scheme == "" {
 			// SCP-style remote (e.g. git@host:repo) — url.Parse either fails or
 			// produces an empty scheme. Both cases require manual host extraction.
-			raw := m.RemoteURL
-			if at := strings.LastIndex(raw, "@"); at != -1 {
-				raw = raw[at+1:]
-			}
-			colon := strings.LastIndex(raw, ":")
-			if colon == -1 {
-				// No colon means we cannot extract a host — reject to avoid
-				// bypassing SSRF validation on malformed remote URLs.
-				b.logger.Warn("push mirror: cannot extract host from SCP-style remote (no colon)", "remote", m.RemoteURL)
+			host, scpErr := extractSCPHost(m.RemoteURL)
+			if scpErr != nil {
+				b.logger.Warn("push mirror: cannot extract host from SCP-style remote", "remote", m.RemoteURL, "err", scpErr)
 				continue
-			}
-			host := raw[:colon]
-			host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
-			// Strip IPv6 zone identifier (e.g. "::1%eth0" -> "::1") before
-			// validation. Some platforms resolve scoped addresses successfully,
-			// which could let ::1%zone bypass the loopback check in ValidateHost.
-			if z := strings.IndexByte(host, '%'); z != -1 {
-				host = host[:z]
 			}
 			if ssrfErr := ssrf.ValidateHost(ctx, host); ssrfErr != nil {
 				b.logger.Warn("push mirror: SSRF check failed", "remote", m.RemoteURL, "err", ssrfErr)
@@ -158,4 +144,25 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 	// PushMirrors itself is called from a goroutine in syncRepoMeta,
 	// so blocking here does not delay the push response to the git client.
 	wg.Wait()
+}
+
+// extractSCPHost parses the host from an SCP-style git remote URL
+// (e.g. git@host:repo or host:repo). Returns an error if no host can be
+// determined. Strips IPv6 brackets and zone identifiers before returning.
+func extractSCPHost(raw string) (string, error) {
+	if at := strings.LastIndex(raw, "@"); at != -1 {
+		raw = raw[at+1:]
+	}
+	colon := strings.LastIndex(raw, ":")
+	if colon == -1 {
+		return "", fmt.Errorf("cannot extract host from SCP-style remote (no colon): %q", raw)
+	}
+	host := raw[:colon]
+	host = strings.TrimPrefix(strings.TrimSuffix(host, "]"), "[")
+	// Strip IPv6 zone identifier (e.g. "::1%eth0" -> "::1") to prevent
+	// scoped addresses from bypassing the loopback check in ValidateHost.
+	if z := strings.IndexByte(host, '%'); z != -1 {
+		host = host[:z]
+	}
+	return host, nil
 }

--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -298,10 +298,23 @@ func (d *Backend) ImportRepository(ctx context.Context, name string, user proto.
 	// path Run sends to done before p.fn has had a chance to send to repoc;
 	// blocking on <-repoc first would deadlock until the import goroutine
 	// eventually completes. Use select to handle whichever arrives first.
+	//
+	// When done fires with a nil error (e.g. context cancelled after the
+	// import succeeded), drain repoc non-blocking so the caller still gets
+	// the repository value that was already produced.
 	select {
 	case r := <-repoc:
 		return r, <-done
 	case err := <-done:
+		if err == nil {
+			// Import may have completed just before the context fired;
+			// return the repository if available.
+			select {
+			case r := <-repoc:
+				return r, nil
+			default:
+			}
+		}
 		return nil, err
 	}
 }

--- a/pkg/hooks/gen.go
+++ b/pkg/hooks/gen.go
@@ -27,7 +27,8 @@ const (
 // - post-update
 //
 // This function should be called by the backend when a repository is created.
-// TODO: support context.
+// The context parameter is accepted for future use (e.g. cancellation during
+// slow filesystem operations) but is not yet consumed by the implementation.
 func GenerateHooks(_ context.Context, cfg *config.Config, repo string) error {
 	repo = utils.SanitizeRepo(repo) + ".git"
 	hooksPath := filepath.Join(cfg.DataPath, "repos", repo, "hooks")

--- a/pkg/ssrf/ssrf.go
+++ b/pkg/ssrf/ssrf.go
@@ -48,12 +48,19 @@ func NewSecureClient() *http.Client {
 					if len(addrs) == 0 {
 						return nil, fmt.Errorf("no IP addresses found for host: %s", host)
 					}
+					// Reject if ANY resolved IP is private/internal.
+					// Select the first public IP for dialing so that DNS
+					// round-robin cannot swap in a private address on retry.
+					var selectedIP net.IP
 					for _, addr := range addrs {
 						if isPrivateOrInternal(addr.IP) {
 							return nil, fmt.Errorf("%w", ErrPrivateIP)
 						}
+						if selectedIP == nil {
+							selectedIP = addr.IP
+						}
 					}
-					ip = addrs[0].IP
+					ip = selectedIP
 				}
 				if isPrivateOrInternal(ip) {
 					return nil, fmt.Errorf("%w", ErrPrivateIP)

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -152,6 +152,10 @@ func (m *Manager) Run(id string, done chan<- error) {
 		// Delay map deletion until the p.fn goroutine has fully exited so that
 		// a concurrent Add(id, ...) + Run(id, ...) cannot start a new task for
 		// the same id while the old goroutine is still executing p.fn.
+		//
+		// Callers must not re-Add a task with the same id until they have
+		// observed a Stop() or a completion result from Run(), otherwise the
+		// new Add() will silently no-op (LoadOrStore sees the stale entry).
 		go func() {
 			<-errc
 			m.m.Delete(id)


### PR DESCRIPTION
## Summary
- `pkg/backend/repo.go`: fix ImportRepository select race (drain repoc on nil done)
- `pkg/ssrf/ssrf.go`: select first public IP in DialContext, not blindly addrs[0]
- `pkg/task/manager.go`: document re-Add race window
- `pkg/backend/push_mirror.go`: extract extractSCPHost helper
- `pkg/hooks/gen.go`: replace stale TODO comment

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/task/... ./pkg/web/... ./pkg/backend/... ./pkg/ssrf/... ./pkg/hooks/...` passes

Closes #135