### PR TITLE
fix: round 49 — ImportRepository nil-nil edge case, comment cleanup

### DIFF
--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -293,26 +293,23 @@ func (d *Backend) ImportRepository(ctx context.Context, name string, user proto.
 		d.manager.Run(tid, done)
 	}()
 
-	// Both channels are buffered (cap 1). In the normal path p.fn sends to
-	// repoc before returning, then Run delivers to done. In the cancellation
-	// path Run sends to done before p.fn has had a chance to send to repoc;
-	// blocking on <-repoc first would deadlock until the import goroutine
-	// eventually completes. Use select to handle whichever arrives first.
-	//
-	// When done fires with a nil error (e.g. context cancelled after the
-	// import succeeded), drain repoc non-blocking so the caller still gets
-	// the repository value that was already produced.
+	// Use select: repoc and done are both buffered (cap 1). Normal path sends
+	// repoc first then done; cancellation path sends done first.
 	select {
 	case r := <-repoc:
 		return r, <-done
 	case err := <-done:
 		if err == nil {
 			// Import may have completed just before the context fired;
-			// return the repository if available.
+			// return the repository if already produced.
 			select {
 			case r := <-repoc:
 				return r, nil
 			default:
+				// done fired before repoc was populated — the import goroutine
+				// completed (nil error) but the repository value is not yet
+				// available. Return an error so callers never observe (nil, nil).
+				return nil, fmt.Errorf("import: repository unavailable after completion")
 			}
 		}
 		return nil, err

--- a/pkg/web/git.go
+++ b/pkg/web/git.go
@@ -322,9 +322,9 @@ func withAccess(next http.Handler) http.HandlerFunc {
 		// - git-lfs
 		//
 		// Routes that carry no service var and no info/lfs prefix (e.g. the raw
-		// blob endpoint, go-get) intentionally fall through this switch with no
-		// case matched. They are then subject to the catch-all access check below
-		// (lines ~359-371) which enforces ReadOnlyAccess via renderNotFound.
+		// blob endpoint, go-get) have no matching case in this switch (no default
+		// case). They fall through to the catch-all access check below which
+		// enforces ReadOnlyAccess via renderNotFound.
 		switch {
 		case service == git.ReceivePackService:
 			if accessLevel < access.ReadWriteAccess {


### PR DESCRIPTION
## Summary
- `pkg/backend/repo.go`: return error instead of (nil, nil) when done fires before repoc
- Comment cleanup in both files

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/backend/... ./pkg/web/...` passes

Closes #137