### PR TITLE
fix: round 51 — push-mirror DNS rebinding mitigation, singleflight ctx, webhooks style

### DIFF
--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -121,17 +122,29 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 			}
 			if sshCmd := os.Getenv("GIT_SSH_COMMAND"); sshCmd != "" {
 				cmd.Env = append(cmd.Env, "GIT_SSH_COMMAND="+sshCmd)
-			} else if sockPath := os.Getenv("SSH_AUTH_SOCK"); sockPath != "" {
-				// SSH_AUTH_SOCK is a Unix socket path from the process environment.
-				// It is not influenced by user input (mirror URLs are validated
-				// separately), so forwarding it here is safe. A newline in this
-				// value would malform the env block; os.Getenv strips NUL bytes
-				// but not newlines — reject the value if it contains one.
-				if strings.ContainsAny(sockPath, "\n\r\x00") {
-					b.logger.Warn("push-mirror: SSH_AUTH_SOCK contains unsafe characters, skipping agent forwarding")
-				} else {
-					cmd.Env = append(cmd.Env, "SSH_AUTH_SOCK="+sockPath)
+			} else {
+				// Build a default GIT_SSH_COMMAND that pins host fingerprints into a
+				// per-server known_hosts file. StrictHostKeyChecking=accept-new records
+				// the fingerprint on first connection and rejects changes thereafter,
+				// narrowing the DNS rebinding window: an attacker who swaps the DNS
+				// record after the initial SSRF check will be blocked by the pinned key.
+				// This is a best-effort mitigation — it does not eliminate the window
+				// between SSRF validation and the first SSH handshake.
+				knownHostsFile := filepath.Join(b.cfg.DataPath, "mirror_known_hosts")
+				sshCommand := "ssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=" + knownHostsFile
+				if sockPath := os.Getenv("SSH_AUTH_SOCK"); sockPath != "" {
+					// SSH_AUTH_SOCK is a Unix socket path from the process environment.
+					// It is not influenced by user input (mirror URLs are validated
+					// separately), so forwarding it here is safe. A newline in this
+					// value would malform the env block; os.Getenv strips NUL bytes
+					// but not newlines — reject the value if it contains one.
+					if strings.ContainsAny(sockPath, "\n\r\x00") {
+						b.logger.Warn("push-mirror: SSH_AUTH_SOCK contains unsafe characters, skipping agent forwarding")
+					} else {
+						cmd.Env = append(cmd.Env, "SSH_AUTH_SOCK="+sockPath)
+					}
 				}
+				cmd.Env = append(cmd.Env, "GIT_SSH_COMMAND="+sshCommand)
 			}
 			if out, err := cmd.CombinedOutput(); err != nil {
 				b.logger.Warn("push-mirror: push failed", "repo", repo.Name(), "mirror", m.Name, "err", err, "output", string(out))

--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -493,14 +493,13 @@ func (d *Backend) RenameRepository(ctx context.Context, oldName string, newName 
 // It implements backend.Backend.
 func (d *Backend) Repositories(ctx context.Context) ([]proto.Repository, error) {
 	// Use singleflight to coalesce concurrent calls and prevent cache stampede.
-	// The context is intentionally not forwarded into Do() because singleflight
-	// shares a single in-flight call across all callers; cancelling one caller's
-	// context would abort the shared work for all. We bound the work via the
-	// database transaction deadline instead.
+	// The lambda uses d.ctx (backend root context) rather than the caller's ctx
+	// so that one caller cancelling does not abort the shared in-flight query
+	// for all other waiters.
 	v, err, _ := d.reposSFG.Do("all", func() (interface{}, error) {
 		repos := make([]proto.Repository, 0)
-		if err := d.db.TransactionContext(ctx, func(tx *db.Tx) error {
-			ms, err := d.store.GetAllRepos(ctx, tx)
+		if err := d.db.TransactionContext(d.ctx, func(tx *db.Tx) error {
+			ms, err := d.store.GetAllRepos(d.ctx, tx)
 			if err != nil {
 				return err
 			}

--- a/pkg/backend/webhooks.go
+++ b/pkg/backend/webhooks.go
@@ -181,7 +181,7 @@ func (b *Backend) UpdateWebhook(ctx context.Context, repo proto.Repository, id i
 		}
 
 		// Prune events that are already in the list.
-		newEvents := make([]int, 0)
+		var newEvents []int
 		for _, e := range updatedEvents {
 			if _, exists := currentSet[int(e)]; !exists {
 				newEvents = append(newEvents, int(e))


### PR DESCRIPTION
## Summary
- `pkg/backend/push_mirror.go`: Default `GIT_SSH_COMMAND` with `StrictHostKeyChecking=accept-new` + persistent `mirror_known_hosts` file, narrowing DNS rebinding window for SSH/SCP mirrors
- `pkg/backend/repo.go`: singleflight lambda captures `d.ctx` instead of caller's ctx
- `pkg/backend/webhooks.go`: `make([]int, 0)` → `var newEvents []int` (style)

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./pkg/backend/...` passes

Closes #141