### PR TITLE
fix: round 52 — shell-quote known_hosts path, ImportRepository log, style NITs

### DIFF
--- a/pkg/backend/lfs.go
+++ b/pkg/backend/lfs.go
@@ -93,6 +93,10 @@ func StoreRepoMissingLFSObjects(ctx context.Context, repo proto.Repository, dbx 
 		}
 	}
 
+	// errChan is closed by SearchPointerBlobs after wg.Wait() completes.
+	// If SearchPointerBlobs sent an error before closing, ok is true and err
+	// holds the error. If it closed without sending (no error), ok is false
+	// and err is nil — the zero value — which we correctly ignore.
 	if err, ok := <-errChan; ok {
 		return err
 	}

--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -78,6 +78,10 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 		} else if err != nil || u.Scheme == "" {
 			// SCP-style remote (e.g. git@host:repo) — url.Parse either fails or
 			// produces an empty scheme. Both cases require manual host extraction.
+			// Note: url.Parse rarely errors on SCP-style strings (it typically
+			// succeeds with an empty scheme), so the err != nil branch here is
+			// largely dead code in practice — the empty-scheme check is the
+			// common path.
 			host, scpErr := extractSCPHost(m.RemoteURL)
 			if scpErr != nil {
 				b.logger.Warn("push mirror: cannot extract host from SCP-style remote", "remote", m.RemoteURL, "err", scpErr)
@@ -131,7 +135,9 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 				// This is a best-effort mitigation — it does not eliminate the window
 				// between SSRF validation and the first SSH handshake.
 				knownHostsFile := filepath.Join(b.cfg.DataPath, "mirror_known_hosts")
-				sshCommand := "ssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=" + knownHostsFile
+				// shellQuote wraps the path in POSIX single-quotes to handle DataPath
+				// values that contain spaces without breaking the SSH argument list.
+				sshCommand := "ssh -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=" + shellQuote(knownHostsFile)
 				if sockPath := os.Getenv("SSH_AUTH_SOCK"); sockPath != "" {
 					// SSH_AUTH_SOCK is a Unix socket path from the process environment.
 					// It is not influenced by user input (mirror URLs are validated

--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -171,7 +171,7 @@ func (d *Backend) ImportRepository(ctx context.Context, name string, user proto.
 	// manager.Add. The task manager's LoadOrStore provides atomic dedup for
 	// concurrent callers, so this is safe for correctness; the stat check is
 	// advisory only.
-	if _, err := os.Stat(rp); err == nil || os.IsExist(err) {
+	if _, err := os.Stat(rp); err == nil || errors.Is(err, fs.ErrExist) {
 		return nil, proto.ErrRepoExist
 	}
 
@@ -306,9 +306,11 @@ func (d *Backend) ImportRepository(ctx context.Context, name string, user proto.
 			case r := <-repoc:
 				return r, nil
 			default:
-				// done fired before repoc was populated — the import goroutine
-				// completed (nil error) but the repository value is not yet
-				// available. Return an error so callers never observe (nil, nil).
+				// This branch should be unreachable: the import goroutine always
+				// sends to repoc before signalling done with a nil error. If it
+				// is reached, something is very wrong — log loudly so it is not
+				// silently swallowed.
+				d.logger.Error("import: done fired with nil error but repoc was empty — this is a bug")
 				return nil, fmt.Errorf("import: repository unavailable after completion")
 			}
 		}

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -148,6 +148,11 @@ func (m *Manager) Run(id string, done chan<- error) {
 
 	select {
 	case <-m.ctx.Done():
+		// Note: p.cancel() fires via defer AFTER this select arm returns, so
+		// the p.fn goroutine's ctx is not yet cancelled at this point.
+		// Callers that observe done's result may briefly see m.Exists(id)==true
+		// until the background goroutine below drains errc and calls Delete.
+		// This is an acceptable narrow window and is documented in the API.
 		done <- m.ctx.Err()
 		// Delay map deletion until the p.fn goroutine has fully exited so that
 		// a concurrent Add(id, ...) + Run(id, ...) cannot start a new task for


### PR DESCRIPTION
## Summary
- `pkg/backend/push_mirror.go`: shell-quote `knownHostsFile` path in `GIT_SSH_COMMAND` (spaces in DataPath would silently break SSH mirrors); add dead-branch comment
- `pkg/backend/repo.go`: `logger.Error` on unreachable defensive branch; `os.IsExist` → `errors.Is(err, fs.ErrExist)`
- `pkg/backend/lfs.go`: clarifying comment for `errChan` receive idiom
- `pkg/task/manager.go`: document narrow `Exists()` window after manager shutdown

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/backend/... ./pkg/task/... ./pkg/web/...` passes

Closes #143