### PR TITLE
fix: round 53 — git.Init mirror clobber, GIT_SSH_COMMAND safety, DeleteRepository atomicity

### DIFF
--- a/pkg/backend/hooks.go
+++ b/pkg/backend/hooks.go
@@ -38,9 +38,9 @@ func (d *Backend) PostReceive(ctx context.Context, _ io.Writer, _ io.Writer, rep
 	// response is not blocked by DB writes or git tree reads.
 	go func() {
 		// The 30-second timeout covers metadata sync (DB writes, YAML parse).
-		// Push mirrors (PushMirrors) run with their own per-push timeout and are
-		// called from syncRepoMeta; they will be cancelled early if this ctx expires
-		// before they complete. Extend this timeout if long-running mirrors are expected.
+		// PushMirrors is called from syncRepoMeta with d.ctx (the backend root
+		// context, not syncCtx), so mirror pushes are NOT constrained by this
+		// timeout — they run with their own per-push mirrorPushTimeout.
 		syncCtx, cancel := context.WithTimeout(d.ctx, 30*time.Second)
 		defer cancel()
 		d.syncRepoMeta(syncCtx, repo, user)

--- a/pkg/backend/lfs.go
+++ b/pkg/backend/lfs.go
@@ -40,6 +40,12 @@ func StoreRepoMissingLFSObjects(ctx context.Context, repo proto.Repository, dbx 
 			}
 
 			defer content.Close() //nolint: errcheck
+			// Disk-ahead-of-DB invariant: strg.Put writes the object to the
+			// filesystem; CreateLFSObject writes the DB row. If strg.Put succeeds
+			// but the DB transaction rolls back, the object file remains on disk
+			// without a corresponding DB row. The re-registration path below
+			// (obj != nil && obj.ID == 0) handles this case on the next download
+			// attempt by re-inserting the DB row without re-downloading the data.
 			return dbx.TransactionContext(ctx, func(tx *db.Tx) error {
 				if err := store.CreateLFSObject(ctx, tx, repo.ID(), p.Oid, p.Size); err != nil {
 					return db.WrapError(err)

--- a/pkg/backend/push_mirror.go
+++ b/pkg/backend/push_mirror.go
@@ -125,7 +125,14 @@ func (b *Backend) PushMirrors(ctx context.Context, repo proto.Repository) {
 				"GIT_CONFIG_COUNT=0",
 			}
 			if sshCmd := os.Getenv("GIT_SSH_COMMAND"); sshCmd != "" {
-				cmd.Env = append(cmd.Env, "GIT_SSH_COMMAND="+sshCmd)
+				// Apply the same safety check used for SSH_AUTH_SOCK: a newline
+				// or NUL in an env var value would malform the env block passed
+				// to the subprocess.
+				if strings.ContainsAny(sshCmd, "\n\r\x00") {
+					b.logger.Warn("push-mirror: GIT_SSH_COMMAND contains unsafe characters, ignoring operator override")
+				} else {
+					cmd.Env = append(cmd.Env, "GIT_SSH_COMMAND="+sshCmd)
+				}
 			} else {
 				// Build a default GIT_SSH_COMMAND that pins host fingerprints into a
 				// per-server known_hosts file. StrictHostKeyChecking=accept-new records

--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -97,10 +97,18 @@ func (d *Backend) CreateRepository(ctx context.Context, name string, user proto.
 			return err
 		}
 
-		rr, err := git.Init(rp, true)
+		// Skip git.Init when the directory is already a valid git repository
+		// (e.g. populated by git.Clone inside ImportRepository). Calling
+		// git.Init on an existing bare clone overwrites the config file,
+		// stripping mirror-specific settings (mirror=true, fetch refspecs).
+		rr, err := git.Open(rp)
 		if err != nil {
-			d.logger.Debug("failed to create repository", "err", err)
-			return err
+			// Directory not yet a git repo — initialize it.
+			rr, err = git.Init(rp, true)
+			if err != nil {
+				d.logger.Debug("failed to create repository", "err", err)
+				return err
+			}
 		}
 
 		if user != nil && user.Username() != "" {
@@ -338,6 +346,11 @@ func (d *Backend) DeleteRepository(ctx context.Context, name string) error {
 		return err
 	}
 
+	// removeDir is set to true inside the transaction only after all DB changes
+	// have succeeded. The actual filesystem removal happens after the transaction
+	// commits so that a DB commit failure cannot leave us with a missing directory
+	// and a stale DB row.
+	var removeDir bool
 	if err := d.db.TransactionContext(ctx, func(tx *db.Tx) error {
 		repom, dberr := d.store.GetRepoByName(ctx, tx, name)
 		_, ferr := os.Stat(rp)
@@ -345,13 +358,12 @@ func (d *Backend) DeleteRepository(ctx context.Context, name string) error {
 			return proto.ErrRepoNotFound
 		}
 
-		// If the repo is not in the database but the directory exists, remove it.
-		// The previous guard (dberr!=nil && ferr!=nil) already returned, so
-		// the only remaining dberr!=nil case here is dberr!=nil && ferr==nil.
-		// os.RemoveAll is idempotent: a transaction retry after a prior
-		// successful removal returns nil safely.
+		// If the repo is not in the database but the directory exists, mark it
+		// for removal after the transaction. The previous guard already returned
+		// when both are missing, so here dberr!=nil implies ferr==nil.
 		if dberr != nil {
-			return os.RemoveAll(rp)
+			removeDir = true
+			return nil
 		}
 
 		repoID := strconv.FormatInt(repom.ID, 10)
@@ -382,13 +394,28 @@ func (d *Backend) DeleteRepository(ctx context.Context, name string) error {
 			return db.WrapError(err)
 		}
 
-		return os.RemoveAll(rp)
+		// Mark for post-commit removal. The directory is only removed after the
+		// transaction commits so that a DB commit failure cannot leave us with
+		// the directory missing but the DB row still present.
+		removeDir = true
+		return nil
 	}); err != nil {
 		if errors.Is(err, db.ErrRecordNotFound) {
 			return proto.ErrRepoNotFound
 		}
 
 		return db.WrapError(err)
+	}
+
+	// The transaction has committed — it is now safe to remove the directory.
+	// os.RemoveAll is idempotent: if the directory is already absent (e.g. from
+	// a prior partial delete), this is a no-op.
+	if removeDir {
+		if err := os.RemoveAll(rp); err != nil {
+			// Non-fatal: DB row is already gone. Log and continue — the orphan
+			// directory will be cleaned up on the next delete attempt.
+			d.logger.Error("failed to remove repository directory after delete", "path", rp, "err", err)
+		}
 	}
 
 	d.cache.Delete(name)
@@ -498,6 +525,11 @@ func (d *Backend) Repositories(ctx context.Context) ([]proto.Repository, error) 
 	// The lambda uses d.ctx (backend root context) rather than the caller's ctx
 	// so that one caller cancelling does not abort the shared in-flight query
 	// for all other waiters.
+	//
+	// Note: the result is a snapshot at query time and is populated into d.cache
+	// (per-repo entries) without an expiry. High-churn environments (frequent
+	// create/delete) should be aware that Repositories() reflects the state at
+	// the time of the most recent coalesced query until the next call.
 	v, err, _ := d.reposSFG.Do("all", func() (interface{}, error) {
 		repos := make([]proto.Repository, 0)
 		if err := d.db.TransactionContext(d.ctx, func(tx *db.Tx) error {

--- a/pkg/ssh/cmd/push_mirror.go
+++ b/pkg/ssh/cmd/push_mirror.go
@@ -44,6 +44,12 @@ func pushMirrorAddCommand() *cobra.Command {
 				return err
 			}
 
+			// Warn when the remote uses plain HTTP — credentials and content
+			// will be sent in the clear over the network.
+			if u, err := url.Parse(remoteURL); err == nil && strings.EqualFold(u.Scheme, "http") {
+				fmt.Fprintln(cmd.ErrOrStderr(), "warning: push mirror uses plain HTTP — credentials and data are not encrypted in transit; consider using HTTPS or SSH")
+			}
+
 			repo, err := be.Repository(ctx, args[0])
 			if err != nil {
 				return err

--- a/pkg/ssrf/ssrf.go
+++ b/pkg/ssrf/ssrf.go
@@ -81,6 +81,10 @@ func NewSecureClient() *http.Client {
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 		},
+		// Refuse all HTTP redirects. For webhooks this prevents SSRF via a
+		// redirect to an internal host. For LFS this is safe because the LFS
+		// batch API returns explicit download/upload href values; the LFS client
+		// calls those URLs directly and does not rely on server-issued redirects.
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			return http.ErrUseLastResponse
 		},

--- a/pkg/store/database/webhooks.go
+++ b/pkg/store/database/webhooks.go
@@ -46,13 +46,18 @@ func (*webhookStore) CreateWebhookEvents(ctx context.Context, h db.Handler, webh
 		return nil
 	}
 	// Bulk INSERT to avoid N round-trips for webhooks with many events.
-	placeholders := make([]string, len(events))
+	// Use strings.Builder to build the placeholder list without intermediate
+	// string allocations from strings.Join over a []string.
+	var pb strings.Builder
 	args := make([]interface{}, 0, len(events)*2)
 	for i, event := range events {
-		placeholders[i] = "(?, ?)"
+		if i > 0 {
+			pb.WriteString(", ")
+		}
+		pb.WriteString("(?, ?)")
 		args = append(args, webhookID, event)
 	}
-	query := h.Rebind(`INSERT INTO webhook_events (webhook_id, event) VALUES ` + strings.Join(placeholders, ", "))
+	query := h.Rebind(`INSERT INTO webhook_events (webhook_id, event) VALUES ` + pb.String())
 	_, err := h.ExecContext(ctx, query, args...)
 	return err
 }

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -47,7 +47,14 @@ func NewManager(ctx context.Context) *Manager {
 }
 
 // Add adds a task to the manager.
-// If the process already exists, it is a no-op.
+// If a task with the same id already exists, Add is a no-op (the existing
+// task is not replaced and fn is discarded).
+//
+// Callers must not call Add for the same id again until they have observed
+// either a Stop() call or a completion result from Run(). During the brief
+// window after Run() returns (manager-shutdown path) and before the map entry
+// is removed by the cleanup goroutine, a subsequent Add will be silently
+// dropped. Use Stop() followed by Add() to reliably replace a task.
 func (m *Manager) Add(id string, fn func(context.Context) error) {
 	ctx, cancel := context.WithCancel(m.ctx)
 	t := &Task{


### PR DESCRIPTION
## Summary
- `CreateRepository` now skips `git.Init` when path is already a valid git repo (fixes mirror config clobber in `ImportRepository`)
- `GIT_SSH_COMMAND` from env now checked for newlines/NUL before use
- `DeleteRepository` moves `os.RemoveAll` after transaction commit for atomicity
- Comments, docs, and style improvements across 8 files

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/backend/... ./pkg/task/... ./pkg/web/... ./pkg/ssrf/...` passes

Closes #145