### PR TITLE
fix: round 54 — LFS batch N+1, mirror scheme validation, dead code, docs

### DIFF
--- a/pkg/backend/repo.go
+++ b/pkg/backend/repo.go
@@ -64,7 +64,7 @@ func (d *Backend) CreateRepository(ctx context.Context, name string, user proto.
 		return nil, err
 	}
 
-	rp := filepath.Join(d.repoPath(name))
+	rp := d.repoPath(name)
 
 	// Clean up the repo directory if the transaction fails — git.Init
 	// creates OS files that the DB rollback cannot undo, which would leave
@@ -164,7 +164,7 @@ func (d *Backend) ImportRepository(ctx context.Context, name string, user proto.
 		return nil, err
 	}
 
-	rp := filepath.Join(d.repoPath(name))
+	rp := d.repoPath(name)
 
 	if d.manager == nil {
 		return nil, fmt.Errorf("import repository: no manager configured")
@@ -179,7 +179,9 @@ func (d *Backend) ImportRepository(ctx context.Context, name string, user proto.
 	// manager.Add. The task manager's LoadOrStore provides atomic dedup for
 	// concurrent callers, so this is safe for correctness; the stat check is
 	// advisory only.
-	if _, err := os.Stat(rp); err == nil || errors.Is(err, fs.ErrExist) {
+	// os.Stat returns nil (path exists) or fs.ErrNotExist (absent). It never
+	// returns fs.ErrExist, so the only relevant check is err == nil.
+	if _, err := os.Stat(rp); err == nil {
 		return nil, proto.ErrRepoExist
 	}
 
@@ -331,7 +333,7 @@ func (d *Backend) ImportRepository(ctx context.Context, name string, user proto.
 // It implements backend.Backend.
 func (d *Backend) DeleteRepository(ctx context.Context, name string) error {
 	name = utils.SanitizeRepo(name)
-	rp := filepath.Join(d.repoPath(name))
+	rp := d.repoPath(name)
 
 	user := proto.UserFromContext(ctx)
 	r, err := d.Repository(ctx, name)
@@ -475,8 +477,8 @@ func (d *Backend) RenameRepository(ctx context.Context, oldName string, newName 
 		return nil
 	}
 
-	op := filepath.Join(d.repoPath(oldName))
-	np := filepath.Join(d.repoPath(newName))
+	op := d.repoPath(oldName)
+	np := d.repoPath(newName)
 	if _, err := os.Stat(op); err != nil {
 		return proto.ErrRepoNotFound
 	}
@@ -540,7 +542,7 @@ func (d *Backend) Repositories(ctx context.Context) ([]proto.Repository, error) 
 			for _, m := range ms {
 				r := &repo{
 					name: m.Name,
-					path: filepath.Join(d.repoPath(m.Name)),
+					path: d.repoPath(m.Name),
 					repo: m,
 				}
 				d.cache.Set(m.Name, r)
@@ -569,7 +571,7 @@ func (d *Backend) Repository(ctx context.Context, name string) (proto.Repository
 		return r, nil
 	}
 
-	rp := filepath.Join(d.repoPath(name))
+	rp := d.repoPath(name)
 	if _, err := os.Stat(rp); err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
 			d.logger.Errorf("failed to stat repository path: %v", err)
@@ -704,7 +706,7 @@ func (d *Backend) SetHidden(ctx context.Context, name string, hidden bool) error
 func (d *Backend) SetDescription(ctx context.Context, name string, desc string) error {
 	name = utils.SanitizeRepo(name)
 	desc = utils.Sanitize(desc)
-	rp := filepath.Join(d.repoPath(name))
+	rp := d.repoPath(name)
 
 	// Delete cache
 	d.cache.Delete(name)
@@ -724,7 +726,7 @@ func (d *Backend) SetDescription(ctx context.Context, name string, desc string) 
 // It implements backend.Backend.
 func (d *Backend) SetPrivate(ctx context.Context, name string, private bool) error {
 	name = utils.SanitizeRepo(name)
-	rp := filepath.Join(d.repoPath(name))
+	rp := d.repoPath(name)
 
 	// Capture the old visibility before updating.
 	oldRepo, err := d.Repository(ctx, name)

--- a/pkg/backend/webhooks.go
+++ b/pkg/backend/webhooks.go
@@ -238,7 +238,7 @@ func (b *Backend) ListWebhookDeliveries(ctx context.Context, repo proto.Reposito
 
 		return nil
 	}); err != nil {
-		return nil, db.WrapError(err)
+		return nil, err
 	}
 
 	ds := make([]webhook.Delivery, len(deliveries))

--- a/pkg/ssh/cmd/push_mirror.go
+++ b/pkg/ssh/cmd/push_mirror.go
@@ -87,7 +87,9 @@ func validateMirrorURL(rawURL string) error {
 		return fmt.Errorf("invalid mirror URL: %w", err)
 	}
 	switch strings.ToLower(u.Scheme) {
-	case "https", "http", "ssh":
+	case "https", "http", "ssh", "git+ssh", "ssh+git":
+		// git+ssh:// and ssh+git:// are aliases for ssh://, supported by the
+		// push engine in pkg/backend/push_mirror.go.
 		return nil
 	case "":
 		// SCP-style SSH remotes (git@host:path) are allowed.

--- a/pkg/ssrf/ssrf.go
+++ b/pkg/ssrf/ssrf.go
@@ -206,6 +206,11 @@ func ValidateIPBeforeDial(ip net.IP) error {
 // ValidateHost resolves host and checks that none of the resolved IPs are
 // private or internal. Use this for non-HTTP schemes (e.g. ssh://) where
 // ValidateURL cannot be used. The provided context is used for the DNS lookup.
+//
+// A 5-second sub-deadline is applied for the DNS lookup regardless of any
+// deadline already present on ctx. If ctx has a tighter deadline, that takes
+// precedence. If ctx has a longer (or no) deadline, the 5-second guard is the
+// effective timeout for the DNS resolution step.
 func ValidateHost(ctx context.Context, host string) error {
 	if host == "" {
 		return fmt.Errorf("%w: missing hostname", ErrInvalidURL)

--- a/pkg/store/database/lfs.go
+++ b/pkg/store/database/lfs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/soft-serve/pkg/db"
 	"github.com/charmbracelet/soft-serve/pkg/db/models"
 	"github.com/charmbracelet/soft-serve/pkg/store"
+	"github.com/jmoiron/sqlx"
 )
 
 type lfsStore struct{}
@@ -193,6 +194,29 @@ func (*lfsStore) GetLFSObjectByOid(ctx context.Context, tx db.Handler, repoID in
 	query := tx.Rebind(`SELECT * FROM lfs_objects WHERE repo_id = ? AND oid = ?;`)
 	err := tx.GetContext(ctx, &obj, query, repoID, oid)
 	return obj, db.WrapError(err)
+}
+
+// GetLFSObjectsByOids implements store.LFSStore.
+// It returns the LFS objects for the given OIDs in a single IN query,
+// eliminating the N+1 pattern in the batch download handler.
+func (*lfsStore) GetLFSObjectsByOids(ctx context.Context, tx db.Handler, repoID int64, oids []string) ([]models.LFSObject, error) {
+	if len(oids) == 0 {
+		return nil, nil
+	}
+	// Convert []string to []interface{} for sqlx.In.
+	args := make([]interface{}, len(oids)+1)
+	args[0] = repoID
+	for i, oid := range oids {
+		args[i+1] = oid
+	}
+	query, args2, err := sqlx.In(`SELECT * FROM lfs_objects WHERE repo_id = ? AND oid IN (?);`, args[0], oids)
+	if err != nil {
+		return nil, err
+	}
+	query = tx.Rebind(query)
+	var objs []models.LFSObject
+	err = tx.SelectContext(ctx, &objs, query, args2...)
+	return objs, db.WrapError(err)
 }
 
 // GetLFSObjects implements store.LFSStore.

--- a/pkg/store/lfs.go
+++ b/pkg/store/lfs.go
@@ -11,6 +11,7 @@ import (
 type LFSStore interface {
 	CreateLFSObject(ctx context.Context, h db.Handler, repoID int64, oid string, size int64) error
 	GetLFSObjectByOid(ctx context.Context, h db.Handler, repoID int64, oid string) (models.LFSObject, error)
+	GetLFSObjectsByOids(ctx context.Context, h db.Handler, repoID int64, oids []string) ([]models.LFSObject, error)
 	GetLFSObjects(ctx context.Context, h db.Handler, repoID int64) ([]models.LFSObject, error)
 	GetLFSObjectsByName(ctx context.Context, h db.Handler, name string) ([]models.LFSObject, error)
 	DeleteLFSObjectByOid(ctx context.Context, h db.Handler, repoID int64, oid string) error

--- a/pkg/task/manager.go
+++ b/pkg/task/manager.go
@@ -55,6 +55,11 @@ func NewManager(ctx context.Context) *Manager {
 // window after Run() returns (manager-shutdown path) and before the map entry
 // is removed by the cleanup goroutine, a subsequent Add will be silently
 // dropped. Use Stop() followed by Add() to reliably replace a task.
+//
+// fn MUST respect context cancellation: when the context passed to fn is
+// cancelled (e.g. via Stop or manager shutdown), fn should return promptly.
+// A task that ignores cancellation will keep its goroutine alive until fn
+// returns naturally — there is no hard deadline imposed by the manager.
 func (m *Manager) Add(id string, fn func(context.Context) error) {
 	ctx, cancel := context.WithCancel(m.ctx)
 	t := &Task{

--- a/pkg/web/git_lfs.go
+++ b/pkg/web/git_lfs.go
@@ -131,6 +131,25 @@ func serviceLfsBatch(w http.ResponseWriter, r *http.Request) {
 	// S3 using object "expires_at" & "expires_in"
 	switch batchRequest.Operation {
 	case lfs.OperationDownload:
+		// Bulk-fetch all requested OIDs in a single query to avoid N+1 DB
+		// round-trips when a batch contains many objects.
+		oids := make([]string, len(batchRequest.Objects))
+		for i, o := range batchRequest.Objects {
+			oids[i] = o.Oid
+		}
+		dbObjs, err := datastore.GetLFSObjectsByOids(ctx, dbx, repo.ID(), oids)
+		if err != nil {
+			logger.Error("error bulk-fetching LFS objects from database", "repo", name, "err", err)
+			renderJSON(w, r, http.StatusInternalServerError, lfs.ErrorResponse{
+				Message: "internal server error",
+			})
+			return
+		}
+		dbObjsByOid := make(map[string]models.LFSObject, len(dbObjs))
+		for _, dbObj := range dbObjs {
+			dbObjsByOid[dbObj.Oid] = dbObj
+		}
+
 		for _, o := range batchRequest.Objects {
 			exist, err := strg.Exists(path.Join("objects", o.RelativePath()))
 			if err != nil && !errors.Is(err, fs.ErrNotExist) {
@@ -141,15 +160,9 @@ func serviceLfsBatch(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			obj, err := datastore.GetLFSObjectByOid(ctx, dbx, repo.ID(), o.Oid)
-			objNotFound := errors.Is(err, db.ErrRecordNotFound)
-			if err != nil && !objNotFound {
-				logger.Error("error getting object from database", "oid", o.Oid, "repo", name, "err", err)
-				renderJSON(w, r, http.StatusInternalServerError, lfs.ErrorResponse{
-					Message: "internal server error",
-				})
-				return
-			}
+			obj, objNotFound := dbObjsByOid[o.Oid]
+			// objNotFound is true when the OID is absent from the DB map.
+			objInDB := !objNotFound
 
 			if !exist {
 				objects = append(objects, &lfs.ObjectResponse{
@@ -159,7 +172,7 @@ func serviceLfsBatch(w http.ResponseWriter, r *http.Request) {
 						Message: "object not found",
 					},
 				})
-			} else if !objNotFound && obj.Size != o.Size {
+			} else if objInDB && obj.Size != o.Size {
 				objects = append(objects, &lfs.ObjectResponse{
 					Pointer: o,
 					Error: &lfs.ObjectError{
@@ -179,8 +192,9 @@ func serviceLfsBatch(w http.ResponseWriter, r *http.Request) {
 					},
 				})
 
-				// If the object doesn't exist in the database, create it
-				if exist && objNotFound {
+				// If the object exists on disk but not in the database,
+				// re-register it (disk-ahead-of-DB recovery path).
+				if exist && !objInDB {
 					if err := datastore.CreateLFSObject(ctx, dbx, repo.ID(), o.Oid, o.Size); err != nil {
 						logger.Error("error creating object in datastore", "oid", o.Oid, "repo", name, "err", err)
 						renderJSON(w, r, http.StatusInternalServerError, lfs.ErrorResponse{


### PR DESCRIPTION
## Summary
- LFS batch download now uses a single bulk query instead of N+1 per-object DB queries
- `validateMirrorURL` now accepts `git+ssh://` and `ssh+git://` (already supported by push engine)
- Dead `fs.ErrExist` arm after `os.Stat` removed; single-arg `filepath.Join` cleaned up
- Double `db.WrapError` in `ListWebhookDeliveries` removed
- `Add` godoc documents context cancellation requirement; `ValidateHost` documents DNS timeout

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/backend/... ./pkg/web/... ./pkg/ssrf/...` passes

Closes #147