### PR TITLE
security: prevent plaintext password storage in database layer

### DIFF
--- a/pkg/store/database/user.go
+++ b/pkg/store/database/user.go
@@ -2,6 +2,8 @@ package database
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/soft-serve/pkg/db"
@@ -15,6 +17,19 @@ import (
 type userStore struct{}
 
 var _ store.UserStore = (*userStore)(nil)
+
+// validateBcryptHash ensures the password is a valid bcrypt hash.
+// This prevents plaintext password storage at the database layer.
+func validateBcryptHash(password string) error {
+	// Bcrypt hashes are approximately 60 characters and start with $2a$ or $2b$
+	if len(password) != 60 {
+		return fmt.Errorf("password must be bcrypt hashed (expected 60 characters, got %d)", len(password))
+	}
+	if !strings.HasPrefix(password, "$2a$") && !strings.HasPrefix(password, "$2b$") {
+		return errors.New("password must be bcrypt hashed")
+	}
+	return nil
+}
 
 // AddPublicKeyByUsername implements store.UserStore.
 func (*userStore) AddPublicKeyByUsername(ctx context.Context, tx db.Handler, username string, pk ssh.PublicKey) error {
@@ -224,6 +239,9 @@ func (*userStore) SetUsernameByUsername(ctx context.Context, tx db.Handler, user
 
 // SetUserPassword implements store.UserStore.
 func (*userStore) SetUserPassword(ctx context.Context, tx db.Handler, userID int64, password string) error {
+	if err := validateBcryptHash(password); err != nil {
+		return err
+	}
 	query := tx.Rebind(`UPDATE users SET password = ? WHERE id = ?;`)
 	_, err := tx.ExecContext(ctx, query, password, userID)
 	return err
@@ -233,6 +251,10 @@ func (*userStore) SetUserPassword(ctx context.Context, tx db.Handler, userID int
 func (*userStore) SetUserPasswordByUsername(ctx context.Context, tx db.Handler, username string, password string) error {
 	username = strings.ToLower(username)
 	if err := utils.ValidateUsername(username); err != nil {
+		return err
+	}
+
+	if err := validateBcryptHash(password); err != nil {
 		return err
 	}
 

--- a/pkg/store/database/user_test.go
+++ b/pkg/store/database/user_test.go
@@ -1,0 +1,90 @@
+package database
+
+import (
+	"testing"
+)
+
+func TestValidateBcryptHash(t *testing.T) {
+	tests := []struct {
+		name     string
+		password  string
+		wantErr  bool
+	}{
+		{
+			name:     "valid bcrypt hash",
+			password:  "$2a$10$gJMBzL9ojgSzRigSiuEEXuGqtm8lOgd3oSMh3QT/JayFJlcMDeLBu", // Valid bcrypt hash
+			wantErr:  false,
+		},
+		{
+			name:     "another valid bcrypt hash",
+			password:  "$2a$10$w64SUzvDxuqVFawwyrCEm..up.DohSRXVXg1b7fPsab9OzojcLeCK", // Valid bcrypt hash
+			wantErr:  false,
+		},
+		{
+			name:     "plaintext password",
+			password:  "mypassword123",
+			wantErr:  true,
+		},
+		{
+			name:     "short hash",
+			password:  "$2a$10$abc",
+			wantErr:  true,
+		},
+		{
+			name:     "long hash",
+			password:  "$2a$10$abcdefghijklmnopqrstuvwxyz1234567890123456789012345",
+			wantErr:  true,
+		},
+		{
+			name:     "wrong prefix",
+			password:  "$1a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad9L2Z2Q",
+			wantErr:  true,
+		},
+		{
+			name:     "empty string",
+			password:  "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBcryptHash(tt.password)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateBcryptHash() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSetUserPasswordWithPlaintext(t *testing.T) {
+	// This test verifies that storing plaintext passwords fails
+	// In a real test, you would need a database connection
+	// For now, we just verify the validation logic
+
+	tests := []struct {
+		name     string
+		password  string
+		wantErr  bool
+	}{
+		{
+			name:     "valid bcrypt hash",
+			password:  "$2a$10$gJMBzL9ojgSzRigSiuEEXuGqtm8lOgd3oSMh3QT/JayFJlcMDeLBu",
+			wantErr:  false,
+		},
+		{
+			name:     "plaintext password should fail",
+			password:  "plaintext123",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateBcryptHash(tt.password)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateBcryptHash(%q) error = %v, wantErr %v", tt.password, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Added validation to ensure passwords are bcrypt hashed before storage at the database layer, preventing plaintext password storage vulnerability.

## Changes
- Added `validateBcryptHash()` helper function to check password format (60 chars, starts with $2a$ or $2b$)
- Updated `SetUserPassword()` to validate password before storage
- Updated `SetUserPasswordByUsername()` to validate password before storage
- Added unit tests for bcrypt hash validation

## Security Risk Addressed
Database backups could contain plaintext passwords if backend layer is bypassed and database layer called directly. This fix ensures the database layer enforces bcrypt hashing.

## Test Plan
- Unit tests verify bcrypt hash validation works correctly
- Tests confirm plaintext passwords are rejected
- Valid bcrypt hashes pass validation

Run tests: `go test ./pkg/store/database -run TestValidateBcryptHash -v`

Closes #152 (Phase 1)